### PR TITLE
Allow scale option passthrough to mmdc

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ With **lazy.nvim**:
       mermaid = {
         background = nil, -- nil | "transparent" | "white" | "#hex"
         theme = nil, -- nil | "default" | "dark" | "forest" | "neutral"
+        scale = 1, -- nil | 1 (default) | 2  | 3 | ...
       },
     }
   },

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -1,6 +1,7 @@
 ---@class MermaidOptions
 ---@field background? string
 ---@field theme? string
+---@field scale? number
 
 ---@type table<string, string>
 local cache = {} -- session cache
@@ -43,6 +44,10 @@ M.render = function(source, options)
   if options.theme then
     table.insert(command_parts, "-t")
     table.insert(command_parts, options.theme)
+  end
+  if options.scale then
+    table.insert(command_parts, "-s")
+    table.insert(command_parts, options.scale)
   end
 
   local command = table.concat(command_parts, " ")


### PR DESCRIPTION
This allows the scale to be passed through to mmdc for those that need bigger text given their setup.

at scale of 1 (current behavior)
<img width="252" alt="image" src="https://github.com/user-attachments/assets/6d53d3ae-0360-4af2-b544-6ea4e503295e">

at scale of 2 (when configured)
<img width="272" alt="image" src="https://github.com/user-attachments/assets/fdef35a1-ff5f-4c19-a616-b6b4f495658c">


at scale of 3
<img width="292" alt="image" src="https://github.com/user-attachments/assets/6fb5e432-85cb-4c65-a3da-dad6bb7b6d69">