### PR TITLE
Add get_cache_dir function to return cache location

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,36 @@ With **lazy.nvim**:
   },
 },
 ```
+
+### Usage
+
+To use the plugin, you need to set up the integrations and renderers in your Neovim configuration. Here's an example:
+
+```lua
+require("diagram").setup({
+  integrations = {
+    require("diagram.integrations.markdown"),
+    require("diagram.integrations.neorg"),
+  },
+  renderer_options = {
+    mermaid = {
+      theme = "forest",
+    },
+    plantuml = {
+      charset = "utf-8",
+    },
+    d2 = {
+      theme_id = 1,
+    },
+  },
+})
+```
+
+### API
+
+The plugin exposes the following API functions:
+
+- `setup(opts)`: Sets up the plugin with the given options.
+- `get_cache_dir()`: Returns the root cache directory.
+
+```

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -116,6 +116,11 @@ local setup = function(opts)
   end
 end
 
+local get_cache_dir = function()
+  return vim.fn.stdpath("cache") .. "/diagram-cache"
+end
+
 return {
   setup = setup,
+  get_cache_dir = get_cache_dir,
 }


### PR DESCRIPTION
Fixes #7

Add a function to return the cache directory.

- Add a new function `get_cache_dir()` in `lua/diagram/init.lua` to return the root cache directory.
- Update `README.md` to document the new `get_cache_dir` function in the usage section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/3rd/diagram.nvim/issues/7?shareId=8cea2742-2e75-4599-993c-da927b04e299).