### PR TITLE
fix: Moved rendered diagram above ranged_verbatim_tag in Neorg

### DIFF
--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -54,13 +54,19 @@ local render_buffer = function(bufnr, winnr, integration)
     local rendered_path = renderer.render(diagram.source, renderer_options)
     if not rendered_path then return end
 
+    local diagram_col = diagram.range.start_col
+    local diagram_row = diagram.range.start_row
+    if vim.bo[bufnr].filetype == "norg" then
+      diagram_row = diagram_row - 1
+    end
+    
     local image = image_nvim.from_file(rendered_path, {
       buffer = bufnr,
       window = winnr,
       with_virtual_padding = true,
       inline = true,
-      x = diagram.range.start_col,
-      y = diagram.range.start_row,
+      x = diagram_col,
+      y = diagram_row,
     })
     diagram.image = image
     table.insert(state.diagrams, diagram)


### PR DESCRIPTION
If custom tree-sitter code folding is added for ranged_verbatim_tags in Neorg, then the @data ... @end can be folded thus removing the diagram src code from polluting the visual space.

![image](https://github.com/user-attachments/assets/51cb2bdd-d501-42cb-b9fd-f58327707999)

![image](https://github.com/user-attachments/assets/c0f1c6e1-ab95-407b-989c-e57af8a210fb)
