### PR TITLE
Remove '>' from input when code block is inside block quote

### DIFF
--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -59,7 +59,7 @@ local render_buffer = function(bufnr, winnr, integration)
     if vim.bo[bufnr].filetype == "norg" then
       diagram_row = diagram_row - 1
     end
-    
+
     local image = image_nvim.from_file(rendered_path, {
       buffer = bufnr,
       window = winnr,

--- a/lua/diagram/integrations/markdown.lua
+++ b/lua/diagram/integrations/markdown.lua
@@ -35,8 +35,8 @@ M.query_buffer_diagrams = function(bufnr)
   for id, node in matches do
     local key = query.captures[id]
     local value = vim.treesitter.get_node_text(node, bufnr)
-    if node:parent():parent():type() == "block_quote" then
-	value = value:gsub("\n>", "\n"):gsub("^>", "")
+    if node:parent():parent() and node:parent():parent():type() == "block_quote" then
+      value = value:gsub("\n>", "\n"):gsub("^>", "")
     end
 
     if key == "info" then

--- a/lua/diagram/integrations/markdown.lua
+++ b/lua/diagram/integrations/markdown.lua
@@ -35,6 +35,9 @@ M.query_buffer_diagrams = function(bufnr)
   for id, node in matches do
     local key = query.captures[id]
     local value = vim.treesitter.get_node_text(node, bufnr)
+    if node:parent():parent():type() == "block_quote" then
+	value = value:gsub("\n>", "\n"):gsub("^>", "")
+    end
 
     if key == "info" then
       ---@diagnostic disable-next-line: unused-local


### PR DESCRIPTION
When a code block is inside a quote block, the extraneous '>'s at the beginning of each line prevent the renderer from successfully rendering the diagram.  When inside a quote block, this removes the > at the start of each line when sending the text to the renderer. 
Goes from
![image](https://github.com/user-attachments/assets/cdb6236e-9479-41c0-a050-f8dfa061f98f)
to
![image](https://github.com/user-attachments/assets/41871d4b-7e0d-4f6d-9039-3f335b4ad90b)

Sorry if anything is wrong, this is my first pull request ever.