### PR TITLE
add options to pupperteer

### DIFF
--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -2,13 +2,14 @@
 ---@field background? string
 ---@field theme? string
 ---@field scale? number
+---@field pupperteer? string
 
 ---@type table<string, string>
 local cache = {} -- session cache
 
 ---@class Renderer<MermaidOptions>
 local M = {
-  id = "mermaid",
+	id = "mermaid",
 }
 
 -- fs cache
@@ -19,54 +20,65 @@ vim.fn.mkdir(tmpdir, "p")
 ---@param options MermaidOptions
 ---@return string|nil
 M.render = function(source, options)
-  local hash = vim.fn.sha256(M.id .. ":" .. source)
-  if cache[hash] then return cache[hash] end
+	local hash = vim.fn.sha256(M.id .. ":" .. source)
+	if cache[hash] then
+		return cache[hash]
+	end
 
-  local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
-  if vim.fn.filereadable(path) == 1 then return path end
+	local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
+	if vim.fn.filereadable(path) == 1 then
+		return path
+	end
 
-  if not vim.fn.executable("mmdc") then error("diagram/mermaid: mmdc not found in PATH") end
+	if not vim.fn.executable("mmdc") then
+		error("diagram/mermaid: mmdc not found in PATH")
+	end
 
-  local tmpsource = vim.fn.tempname()
-  vim.fn.writefile(vim.split(source, "\n"), tmpsource)
+	local tmpsource = vim.fn.tempname()
+	vim.fn.writefile(vim.split(source, "\n"), tmpsource)
 
-  local command_parts = {
-    "mmdc",
-    "-i",
-    tmpsource,
-    "-o",
-    path,
-  }
-  if options.background then
-    table.insert(command_parts, "-b")
-    table.insert(command_parts, options.background)
-  end
-  if options.theme then
-    table.insert(command_parts, "-t")
-    table.insert(command_parts, options.theme)
-  end
-  if options.scale then
-    table.insert(command_parts, "-s")
-    table.insert(command_parts, options.scale)
-  end
-  if options.width then
-    table.insert(command_parts, "--width")
-    table.insert(command_parts, options.width)
-  end
-  if options.height then
-    table.insert(command_parts, "--height")
-    table.insert(command_parts, options.height)
-  end
+	local command_parts = {
+		"mmdc",
+		"-i",
+		tmpsource,
+		"-o",
+		path,
+	}
+	if options.background then
+		table.insert(command_parts, "-b")
+		table.insert(command_parts, options.background)
+	end
+	if options.theme then
+		table.insert(command_parts, "-t")
+		table.insert(command_parts, options.theme)
+	end
+	if options.scale then
+		table.insert(command_parts, "-s")
+		table.insert(command_parts, options.scale)
+	end
+	if options.width then
+		table.insert(command_parts, "--width")
+		table.insert(command_parts, options.width)
+	end
+	if options.height then
+		table.insert(command_parts, "--height")
+		table.insert(command_parts, options.height)
+	end
+	if options.pupperteer then
+		table.insert(command_parts, "-p")
+		table.insert(command_parts, options.pupperteer)
+	end
 
-  local command = table.concat(command_parts, " ")
-  vim.fn.system(command)
-  if vim.v.shell_error ~= 0 then
-    vim.notify("diagram/mermaid: mmdc failed to render diagram", vim.log.levels.ERROR)
-    return nil
-  end
+	local command = table.concat(command_parts, " ")
+	vim.notify(command)
+	vim.fn.system(command)
+	if vim.v.shell_error ~= 0 then
+		vim.notify("diagram/mermaid: mmdc failed to render diagram", vim.log.levels.ERROR)
+		return nil
+	end
 
-  cache[hash] = path
-  return path
+	cache[hash] = path
+	return path
 end
 
 return M


### PR DESCRIPTION
Hello, I hope you are fine.
I installed diagram plugin but I got error with pupperteer and chrome-headless-shell version. I could resolve modify the plugin including an option to set pupperteer directory. 
I Share with you my config plugin file:

```lua
return {
  {
    "hectorcrispens/diagram.nvim",
    dependencies = {
      "3rd/image.nvim",
    },
    opts = { -- you can just pass {}, defaults below
      renderer_options = {
        mermaid = {
          background = "transparent", -- nil | "transparent" | "white" | "#hex"
          theme = "dark", -- nil | "default" | "dark" | "forest" | "neutral"
          scale = 1, -- nil | 1 (default) | 2  | 3 | ...
          width = nil, -- nil | 800 | 400 | ...
          height = nil, -- nil | 600 | 300 | ...
          pupperteer = "/home/hector/.config/pupperteer/puppeteer.config.json",
        },
        plantuml = {
          charset = nil,
        },
        d2 = {
          theme_id = nil,
          dark_theme_id = nil,
          scale = nil,
          layout = nil,
          sketch = nil,
        },
        gnuplot = {
          size = nil, -- nil | "800,600" | ...
          font = nil, -- nil | "Arial,12" | ...
          theme = nil, -- nil | "light" | "dark" | custom theme string
        },
      },
    },
  },
}
```

and pupperter.config.json

```json
{
  "executablePath": "/home/hector/.cache/puppeteer/chrome-headless-shell/linux-132.0.6834.110/chrome-headless-shell-linux64/chrome-headless-shell",
  "puppeteer": {
    "chromiumRevision": "132.0.6834.110"
  }
}
```
I hope this request is useful to improve your plugin.