### PR TITLE
Performance/UX: async rendering, select autocmd events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ With **lazy.nvim**:
     "3rd/image.nvim",
   },
   opts = { -- you can just pass {}, defaults below
+    events = {
+      render_buffer = { "InsertLeave", "BufWinEnter", "TextChanged" },
+      clear_buffer = {"BufLeave"},
+    },
     renderer_options = {
       mermaid = {
         background = nil, -- nil | "transparent" | "white" | "#hex"

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -44,7 +44,7 @@ end
 ---@param integration Integration
 local render_buffer = function(bufnr, winnr, integration)
   local diagrams = integration.query_buffer_diagrams(bufnr)
-  local rendered_flag = false
+  clear_buffer(bufnr)
   for _, diagram in ipairs(diagrams) do
     ---@type Renderer
     local renderer = nil
@@ -78,10 +78,6 @@ local render_buffer = function(bufnr, winnr, integration)
       })
       diagram.image = image
 
-      if not rendered_flag then
-        clear_buffer(bufnr)
-        rendered_flag = true
-      end
       table.insert(state.diagrams, diagram)
       image:render()
     end

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -55,7 +55,7 @@ local render_buffer = function(bufnr, winnr, integration)
 
     local renderer_options = state.renderer_options[renderer.id] or {}
     local rendered_path = renderer.render(diagram.source, renderer_options)
-    if not rendered_path then return end
+    if vim.fn.filereadable(rendered_path) == 0 then return end
 
     local diagram_col = diagram.range.start_col
     local diagram_row = diagram.range.start_row

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -110,8 +110,12 @@ local setup = function(opts)
   local current_ft = vim.bo[current_bufnr].filetype
 
   local setup_buffer = function(bufnr, integration)
+    local events = {
+      render_buffer = { "InsertLeave", "BufWinEnter", "TextChanged" },
+      clear_buffer = {"BufLeave"},
+    }
     -- render
-    vim.api.nvim_create_autocmd({ "InsertLeave", "BufWinEnter", "TextChanged" }, {
+    vim.api.nvim_create_autocmd(events.render_buffer, {
       buffer = bufnr,
       callback = function(buf_ev)
         local winnr = buf_ev.event == "BufWinEnter" and buf_ev.winnr or vim.api.nvim_get_current_win()
@@ -120,12 +124,14 @@ local setup = function(opts)
     })
 
     -- clear
-    vim.api.nvim_create_autocmd("InsertEnter", {
-      buffer = bufnr,
-      callback = function()
-        clear_buffer(bufnr)
-      end,
-    })
+    if events.clear_buffer then
+      vim.api.nvim_create_autocmd(events.clear_buffer, {
+        buffer = bufnr,
+        callback = function()
+          clear_buffer(bufnr)
+        end,
+      })
+    end
   end
 
   -- setup integrations

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -85,12 +85,17 @@ local render_buffer = function(bufnr, winnr, integration)
     if renderer_result.job_id then
       -- Use a timer to poll the job's completion status every 100ms.
       local timer = vim.loop.new_timer()
+      if not timer then return end
       timer:start(0, 100, vim.schedule_wrap(function()
         local result = vim.fn.jobwait({ renderer_result.job_id }, 0)
         if result[1] ~= -1 then
-          timer:stop()
-          timer:close()
-          render_image()
+          if timer:is_active() then
+            timer:stop()
+          end
+          if not timer:is_closing() then
+            timer:close()
+            render_image()
+          end
         end
       end))
     else

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -40,7 +40,7 @@ end
 ---@param integration Integration
 local render_buffer = function(bufnr, winnr, integration)
   local diagrams = integration.query_buffer_diagrams(bufnr)
-
+  local rendered_flag = false
   for _, diagram in ipairs(diagrams) do
     ---@type Renderer
     local renderer = nil
@@ -73,9 +73,12 @@ local render_buffer = function(bufnr, winnr, integration)
         y = diagram_row,
       })
       diagram.image = image
-      table.insert(state.diagrams, diagram)
 
-      clear_buffer(bufnr)
+      if not rendered_flag then
+        clear_buffer(bufnr)
+        rendered_flag = true
+      end
+      table.insert(state.diagrams, diagram)
       image:render()
     end
 
@@ -93,7 +96,6 @@ local render_buffer = function(bufnr, winnr, integration)
     else
       render_image()
     end
-
   end
 end
 

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -3,6 +3,10 @@ local integrations = require("diagram/integrations")
 
 ---@class State
 local state = {
+  events = {
+    render_buffer = { "InsertLeave", "BufWinEnter", "TextChanged" },
+    clear_buffer = {"BufLeave"},
+  },
   renderer_options = {
     mermaid = {
       background = nil,
@@ -112,12 +116,8 @@ local setup = function(opts)
   local current_ft = vim.bo[current_bufnr].filetype
 
   local setup_buffer = function(bufnr, integration)
-    local events = {
-      render_buffer = { "InsertLeave", "BufWinEnter", "TextChanged" },
-      clear_buffer = {"BufLeave"},
-    }
     -- render
-    vim.api.nvim_create_autocmd(events.render_buffer, {
+    vim.api.nvim_create_autocmd(state.events.render_buffer, {
       buffer = bufnr,
       callback = function(buf_ev)
         local winnr = buf_ev.event == "BufWinEnter" and buf_ev.winnr or vim.api.nvim_get_current_win()
@@ -126,8 +126,8 @@ local setup = function(opts)
     })
 
     -- clear
-    if events.clear_buffer then
-      vim.api.nvim_create_autocmd(events.clear_buffer, {
+    if state.events.clear_buffer then
+      vim.api.nvim_create_autocmd(state.events.clear_buffer, {
         buffer = bufnr,
         callback = function()
           clear_buffer(bufnr)

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -39,7 +39,6 @@ end
 ---@param winnr number
 ---@param integration Integration
 local render_buffer = function(bufnr, winnr, integration)
-  clear_buffer(bufnr)
   local diagrams = integration.query_buffer_diagrams(bufnr)
 
   for _, diagram in ipairs(diagrams) do
@@ -75,6 +74,8 @@ local render_buffer = function(bufnr, winnr, integration)
       })
       diagram.image = image
       table.insert(state.diagrams, diagram)
+
+      clear_buffer(bufnr)
       image:render()
     end
 

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -7,6 +7,7 @@ local state = {
     mermaid = {
       background = nil,
       theme = nil,
+      scale = nil,
       width = nil,
       height = nil,
     },

--- a/lua/diagram/renderers/d2.lua
+++ b/lua/diagram/renderers/d2.lua
@@ -13,8 +13,8 @@ local M = {
 }
 
 -- fs cache
-local tmpdir = vim.fn.resolve(vim.fn.stdpath("cache") .. "/diagram-cache/d2")
-vim.fn.mkdir(tmpdir, "p")
+local cache_dir = vim.fn.resolve(vim.fn.stdpath("cache") .. "/diagram-cache/d2")
+vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options D2Options
@@ -22,7 +22,7 @@ vim.fn.mkdir(tmpdir, "p")
 M.render = function(source, options)
 	local hash = vim.fn.sha256(M.id .. ":" .. source)
 
-	local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
+	local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
 	if vim.fn.filereadable(path) == 1 then
 		return path
 	end

--- a/lua/diagram/renderers/d2.lua
+++ b/lua/diagram/renderers/d2.lua
@@ -37,7 +37,7 @@ M.render = function(source, options)
 	local command_parts = {
 		"d2",
 		tmpsource,
-		path .. ".new", -- HACK: write to .new to prevent rendering a incomplete file
+		path .. ".new.png", -- HACK: write to .new.png to prevent rendering a incomplete file
 	}
 	if options.theme_id then
 		table.insert(command_parts, "-t")
@@ -62,7 +62,7 @@ M.render = function(source, options)
 	local command = table.concat(command_parts, " ")
 
   local job_id = vim.fn.jobstart(
-    command .. ".new", -- HACK: write to .new to prevent rendering a incomplete file
+    command,
     {
       on_stdout = function(job_id, data, event) end,
       on_stderr = function(job_id, data, event)
@@ -73,7 +73,7 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         -- vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new", path) -- HACK: rename to remove .new
+        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new.png
       end,
     }
   )

--- a/lua/diagram/renderers/d2.lua
+++ b/lua/diagram/renderers/d2.lua
@@ -6,7 +6,6 @@
 ---@field sketch? boolean
 
 ---@type table<string, string>
-local cache = {} -- session cache
 
 ---@class Renderer<D2Options>
 local M = {
@@ -22,9 +21,6 @@ vim.fn.mkdir(tmpdir, "p")
 ---@return string|nil
 M.render = function(source, options)
 	local hash = vim.fn.sha256(M.id .. ":" .. source)
-	if cache[hash] then
-		return cache[hash]
-	end
 
 	local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
 	if vim.fn.filereadable(path) == 1 then
@@ -70,7 +66,6 @@ M.render = function(source, options)
 		return nil
 	end
 
-	cache[hash] = path
 	return path
 end
 

--- a/lua/diagram/renderers/d2.lua
+++ b/lua/diagram/renderers/d2.lua
@@ -35,7 +35,7 @@ M.render = function(source, options)
 	local command_parts = {
 		"d2",
 		tmpsource,
-		path .. ".new.png", -- HACK: write to .new.png to prevent rendering a incomplete file
+		path
 	}
 	if options.theme_id then
 		table.insert(command_parts, "-t")
@@ -71,7 +71,6 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         -- vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new.png
       end,
     }
   )

--- a/lua/diagram/renderers/d2.lua
+++ b/lua/diagram/renderers/d2.lua
@@ -23,9 +23,7 @@ M.render = function(source, options)
 	local hash = vim.fn.sha256(M.id .. ":" .. source)
 
 	local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
-	if vim.fn.filereadable(path) == 1 then
-		return path
-	end
+  if vim.fn.filereadable(path) == 1 then return { file_path = path } end
 
 	if not vim.fn.executable("d2") then
 		error("diagram/d2: d2 not found in PATH")

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -70,7 +70,10 @@ M.render = function(source, options)
     command,
     {
       on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
-      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr") end,
+      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr")
+        vim.notify("diagram/mermaid: mmdc failed to render diagram. Error: " .. data, vim.log.levels.ERROR)
+        return nil
+      end,
       on_exit = function(job_id, exit_code, event)
         local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         vim.api.nvim_out_write(msg .. "\n")
@@ -78,11 +81,6 @@ M.render = function(source, options)
       end,
     }
   )
-  -- if vim.v.shell_error ~= 0 then
-  --   vim.notify("diagram/mermaid: mmdc failed to render diagram", vim.log.levels.ERROR)
-  --   return nil
-  -- end
-
   return { file_path = path, job_id = job_id }
 end
 

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -18,7 +18,7 @@ vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options MermaidOptions
----@return string|nil
+---@return table|nil
 M.render = function(source, options)
   local hash = vim.fn.sha256(M.id .. ":" .. source)
   local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
@@ -61,12 +61,12 @@ M.render = function(source, options)
 
   local function on_event(job_id, data, event)
     if data and #data > 0 then
-      local msg = string.format("[%s] Job %d: %s", event, job_id, table.concat(data, "\n"))
+      local msg = string.format("[%s] Job %d", event, job_id)
       vim.api.nvim_out_write(msg .. "\n")
     end
   end
 
-  vim.fn.jobstart(
+  local job_id = vim.fn.jobstart(
     command,
     {
       on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
@@ -82,7 +82,7 @@ M.render = function(source, options)
   --   return nil
   -- end
 
-  return path
+  return { file_path = path, job_id = job_id }
 end
 
 return M

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -59,25 +59,18 @@ M.render = function(source, options)
 
   local command = table.concat(command_parts, " ")
 
-  local function on_event(job_id, data, event)
-    if data and #data > 0 then
-      local msg = string.format("[%s] Job %d", event, job_id)
-      vim.api.nvim_out_write(msg .. "\n")
-    end
-  end
-
   local job_id = vim.fn.jobstart(
     command,
     {
-      on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
-      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr")
+      on_stdout = function(job_id, data, event) end,
+      on_stderr = function(job_id, data, event)
         local error_msg = table.concat(data, "\n")
         vim.notify("diagram/mermaid: mmdc failed to render diagram. Error: " .. error_msg, vim.log.levels.ERROR)
         return nil
       end,
       on_exit = function(job_id, exit_code, event)
-        local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
-        vim.api.nvim_out_write(msg .. "\n")
+        -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
+        -- vim.api.nvim_out_write(msg .. "\n")
         vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new
       end,
     }

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -71,7 +71,8 @@ M.render = function(source, options)
     {
       on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
       on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr")
-        vim.notify("diagram/mermaid: mmdc failed to render diagram. Error: " .. data, vim.log.levels.ERROR)
+        local error_msg = table.concat(data, "\n")
+        vim.notify("diagram/mermaid: mmdc failed to render diagram. Error: " .. error_msg, vim.log.levels.ERROR)
         return nil
       end,
       on_exit = function(job_id, exit_code, event)

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -34,7 +34,7 @@ M.render = function(source, options)
     "-i",
     tmpsource,
     "-o",
-    path .. ".new.png", -- HACK: write to .new to prevent rendering a incomplete file
+    path .. ".new.png", -- HACK: write to .new.png to prevent rendering a incomplete file
   }
   if options.background then
     table.insert(command_parts, "-b")
@@ -71,7 +71,7 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         -- vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new
+        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new.png
       end,
     }
   )

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -34,7 +34,7 @@ M.render = function(source, options)
     "-i",
     tmpsource,
     "-o",
-    path .. ".new", -- HACK: write to .new to prevent rendering a incomplete file
+    path .. ".new.png", -- HACK: write to .new to prevent rendering a incomplete file
   }
   if options.background then
     table.insert(command_parts, "-b")
@@ -77,7 +77,7 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new", path) -- HACK: rename to remove .new
+        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new
       end,
     }
   )

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -6,7 +6,6 @@
 ---@field height? number
 
 ---@type table<string, string>
-local cache = {} -- session cache
 
 ---@class Renderer<MermaidOptions>
 local M = {
@@ -22,8 +21,6 @@ vim.fn.mkdir(tmpdir, "p")
 ---@return string|nil
 M.render = function(source, options)
   local hash = vim.fn.sha256(M.id .. ":" .. source)
-  if cache[hash] then return cache[hash] end
-
   local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
   if vim.fn.filereadable(path) == 1 then return path end
 
@@ -85,7 +82,6 @@ M.render = function(source, options)
   --   return nil
   -- end
 
-  cache[hash] = path
   return path
 end
 

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -61,9 +61,19 @@ M.render = function(source, options)
   end
 
   local command = table.concat(command_parts, " ")
+
+  local function on_event(job_id, data, event)
+    if data and #data > 0 then
+      local msg = string.format("[%s] Job %d: %s", event, job_id, table.concat(data, "\n"))
+      vim.api.nvim_out_write(msg .. "\n")
+    end
+  end
+
   vim.fn.jobstart(
     command,
     {
+      on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
+      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr") end,
       on_exit = function(job_id, exit_code, event)
         local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         vim.api.nvim_out_write(msg .. "\n")

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -34,7 +34,7 @@ M.render = function(source, options)
     "-i",
     tmpsource,
     "-o",
-    path .. ".new.png", -- HACK: write to .new.png to prevent rendering a incomplete file
+    path
   }
   if options.background then
     table.insert(command_parts, "-b")
@@ -71,7 +71,6 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         -- vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new.png
       end,
     }
   )

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -2,6 +2,8 @@
 ---@field background? string
 ---@field theme? string
 ---@field scale? number
+---@field width? number
+---@field height? number
 
 ---@type table<string, string>
 local cache = {} -- session cache

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -13,15 +13,15 @@ local M = {
 }
 
 -- fs cache
-local tmpdir = vim.fn.resolve(vim.fn.stdpath("cache") .. "/diagram-cache/mermaid")
-vim.fn.mkdir(tmpdir, "p")
+local cache_dir = vim.fn.resolve(vim.fn.stdpath("cache") .. "/diagram-cache/mermaid")
+vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options MermaidOptions
 ---@return string|nil
 M.render = function(source, options)
   local hash = vim.fn.sha256(M.id .. ":" .. source)
-  local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
+  local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
   if vim.fn.filereadable(path) == 1 then return path end
 
   if not vim.fn.executable("mmdc") then error("diagram/mermaid: mmdc not found in PATH") end

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -61,11 +61,19 @@ M.render = function(source, options)
   end
 
   local command = table.concat(command_parts, " ")
-  vim.fn.system(command)
-  if vim.v.shell_error ~= 0 then
-    vim.notify("diagram/mermaid: mmdc failed to render diagram", vim.log.levels.ERROR)
-    return nil
-  end
+  vim.fn.jobstart(
+    command,
+    {
+      on_exit = function(job_id, exit_code, event)
+        local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
+        vim.api.nvim_out_write(msg .. "\n")
+      end,
+    }
+  )
+  -- if vim.v.shell_error ~= 0 then
+  --   vim.notify("diagram/mermaid: mmdc failed to render diagram", vim.log.levels.ERROR)
+  --   return nil
+  -- end
 
   cache[hash] = path
   return path

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -34,7 +34,7 @@ M.render = function(source, options)
     "-i",
     tmpsource,
     "-o",
-    path,
+    path .. ".new", -- HACK: write to .new to prevent rendering a incomplete file
   }
   if options.background then
     table.insert(command_parts, "-b")
@@ -74,6 +74,7 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         vim.api.nvim_out_write(msg .. "\n")
+        vim.fn.rename(path .. ".new", path) -- HACK: rename to remove .new
       end,
     }
   )

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -22,7 +22,7 @@ vim.fn.mkdir(cache_dir, "p")
 M.render = function(source, options)
   local hash = vim.fn.sha256(M.id .. ":" .. source)
   local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
-  if vim.fn.filereadable(path) == 1 then return path end
+  if vim.fn.filereadable(path) == 1 then return { file_path = path } end
 
   if not vim.fn.executable("mmdc") then error("diagram/mermaid: mmdc not found in PATH") end
 

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -40,26 +40,18 @@ M.render = function(source, options)
 
   local command = table.concat(command_parts, " ")
 
-  local function on_event(job_id, data, event)
-    if data and #data > 0 then
-      local msg = string.format("[%s] Job %d", event, job_id)
-      vim.api.nvim_out_write(msg .. "\n")
-    end
-  end
-
   local job_id = vim.fn.jobstart(
     command .. " > " .. vim.fn.shellescape(path .. ".new"), -- HACK: write to .new to prevent rendering a incomplete file
     {
-      on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
-      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr")
-        -- data is not a string
+      on_stdout = function(job_id, data, event) end,
+      on_stderr = function(job_id, data, event)
         local error_msg = table.concat(data, "\n")
-        vim.notify("diagram/plantuml: plantuml failed to render diagram. Error: " .. error_msg, vim.log.levels.ERROR)
+        vim.notify("diagram/plantuml: plantuml failed to render diagram.\nError: " .. error_msg, vim.log.levels.ERROR)
         return nil
       end,
       on_exit = function(job_id, exit_code, event)
-        local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
-        vim.api.nvim_out_write(msg .. "\n")
+        -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
+        -- vim.api.nvim_out_write(msg .. "\n")
         vim.fn.rename(path .. ".new", path) -- HACK: rename to remove .new
       end,
     }

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -41,7 +41,7 @@ M.render = function(source, options)
   local command = table.concat(command_parts, " ")
 
   local job_id = vim.fn.jobstart(
-    command .. " > " .. vim.fn.shellescape(path .. ".new"), -- HACK: write to .new to prevent rendering a incomplete file
+    command .. " > " .. vim.fn.shellescape(path .. ".new.png"), -- HACK: write to .new.png to prevent rendering a incomplete file
     {
       on_stdout = function(job_id, data, event) end,
       on_stderr = function(job_id, data, event)
@@ -52,7 +52,7 @@ M.render = function(source, options)
       on_exit = function(job_id, exit_code, event)
         -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         -- vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new", path) -- HACK: rename to remove .new
+        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new.png
       end,
     }
   )

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -9,8 +9,8 @@ local M = {
 }
 
 -- fs cache
-local tmpdir = vim.fn.resolve(vim.fn.stdpath("cache") .. "/diagram-cache/plantuml")
-vim.fn.mkdir(tmpdir, "p")
+local cache_dir = vim.fn.resolve(vim.fn.stdpath("cache") .. "/diagram-cache/plantuml")
+vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options PlantUMLOptions
@@ -18,7 +18,7 @@ vim.fn.mkdir(tmpdir, "p")
 M.render = function(source, options)
   local hash = vim.fn.sha256(M.id .. ":" .. source)
 
-  local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
+  local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
   if vim.fn.filereadable(path) == 1 then return path end
 
   if not vim.fn.executable("plantuml") then error("diagram/plantuml: plantuml not found in PATH") end

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -48,13 +48,14 @@ M.render = function(source, options)
   end
 
   local job_id = vim.fn.jobstart(
-    command .. " > " .. vim.fn.shellescape(path),
+    command .. " > " .. vim.fn.shellescape(path .. ".new"), -- HACK: write to .new to prevent rendering a incomplete file
     {
       on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
       on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr") end,
       on_exit = function(job_id, exit_code, event)
         local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         vim.api.nvim_out_write(msg .. "\n")
+        vim.fn.rename(path .. ".new", path) -- HACK: rename to remove .new
       end,
     }
   )

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -2,7 +2,6 @@
 ---@field charset? string
 
 ---@type table<string, string>
-local cache = {} -- session cache
 
 ---@class Renderer<PlantUMLOptions>
 local M = {
@@ -18,7 +17,6 @@ vim.fn.mkdir(tmpdir, "p")
 ---@return string|nil
 M.render = function(source, options)
   local hash = vim.fn.sha256(M.id .. ":" .. source)
-  if cache[hash] then return cache[hash] end
 
   local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
   if vim.fn.filereadable(path) == 1 then return path end
@@ -47,7 +45,6 @@ M.render = function(source, options)
     return nil
   end
 
-  cache[hash] = path
   return path
 end
 

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -52,7 +52,9 @@ M.render = function(source, options)
     {
       on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
       on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr")
-        vim.notify("diagram/plantuml: plantuml failed to render diagram. Error: " .. data, vim.log.levels.ERROR)
+        -- data is not a string
+        local error_msg = table.concat(data, "\n")
+        vim.notify("diagram/plantuml: plantuml failed to render diagram. Error: " .. error_msg, vim.log.levels.ERROR)
         return nil
       end,
       on_exit = function(job_id, exit_code, event)

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -51,7 +51,10 @@ M.render = function(source, options)
     command .. " > " .. vim.fn.shellescape(path .. ".new"), -- HACK: write to .new to prevent rendering a incomplete file
     {
       on_stdout = function(job_id, data, event) on_event(job_id, data, "stdout") end,
-      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr") end,
+      on_stderr = function(job_id, data, event) on_event(job_id, data, "stderr")
+        vim.notify("diagram/plantuml: plantuml failed to render diagram. Error: " .. data, vim.log.levels.ERROR)
+        return nil
+      end,
       on_exit = function(job_id, exit_code, event)
         local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
         vim.api.nvim_out_write(msg .. "\n")


### PR DESCRIPTION
### Goal

- [x] improve UX
- [x] render diagrams asynchronously
- [x] allow users to select events that will trigger (clear/render)_buffer
- [ ] display the new diagram only after the new one is generated.

### Testing
With lazy
```
{
  'propilideno/diagram.nvim',
  ft = { "markdown" },
  branch = "perf/async_rendering",
  dependencies = {
    "3rd/image.nvim",
  },
}
```