### PR TITLE
feat(hover): add manual diagram viewing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ The plugin exposes the following API functions:
 
 - `setup(opts)`: Sets up the plugin with the given options.
 - `get_cache_dir()`: Returns the root cache directory.
+- `show_diagram_hover()`: Shows the diagram at cursor in a new tab (for manual keybinding).

--- a/README.md
+++ b/README.md
@@ -104,3 +104,56 @@ The plugin exposes the following API functions:
 - `setup(opts)`: Sets up the plugin with the given options.
 - `get_cache_dir()`: Returns the root cache directory.
 - `show_diagram_hover()`: Shows the diagram at cursor in a new tab (for manual keybinding).
+
+### Diagram Hover Feature
+
+You can add a keymap to view diagrams in a dedicated tab. Place your cursor inside any diagram code block and press the mapped key to open the rendered diagram in a new tab.
+
+**Important**: This keymap configuration is essential for manual diagram viewing, especially when you have automatic rendering disabled.
+
+```lua
+{
+  "3rd/diagram.nvim",
+  dependencies = {
+    "3rd/image.nvim",
+  },
+  opts = {
+    -- Disable automatic rendering for manual-only workflow
+    events = {
+      render_buffer = {}, -- Empty = no automatic rendering
+      clear_buffer = { "BufLeave" },
+    },
+    renderer_options = {
+      mermaid = {
+        theme = "dark",
+        scale = 2,
+      },
+    },
+  },
+  keys = {
+    {
+      "K", -- or any key you prefer
+      function()
+        require("diagram").show_diagram_hover()
+      end,
+      mode = "n",
+      ft = { "markdown", "norg" }, -- Only in these filetypes
+      desc = "Show diagram in new tab",
+    },
+  },
+},
+```
+
+**Key Configuration Details:**
+- `"K"` - The key to press (can be changed to any key like `"<leader>d"`, `"gd"`, etc.)
+- `ft = { "markdown", "norg" }` - Only activates in markdown and neorg files
+- The function calls `require("diagram").show_diagram_hover()` to display the diagram
+
+**Features:**
+- **Cursor detection**: Works when cursor is anywhere inside diagram code blocks
+- **New tab display**: Opens diagram in a dedicated tab with proper image rendering
+- **Multiple diagram types**: Supports mermaid, plantuml, d2, and gnuplot
+- **Easy navigation**: 
+  - `q` or `Esc` to close the diagram tab
+  - `o` to open the image with system viewer (Preview, etc.)
+- **Async rendering**: Handles both cached and newly-rendered diagrams

--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -1,0 +1,166 @@
+local image_nvim = require("image")
+
+local M = {}
+
+---@param bufnr number
+---@param integrations Integration[]
+---@return Diagram|nil
+local get_diagram_at_cursor = function(bufnr, integrations)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local row = cursor[1] - 1 -- 0-indexed
+  local col = cursor[2]
+  
+  -- Find matching integration for current filetype
+  local ft = vim.bo[bufnr].filetype
+  local integration = nil
+  for _, integ in ipairs(integrations) do
+    if vim.tbl_contains(integ.filetypes, ft) then
+      integration = integ
+      break
+    end
+  end
+  
+  if not integration then return nil end
+  
+  local diagrams = integration.query_buffer_diagrams(bufnr)
+  for _, diagram in ipairs(diagrams) do
+    if row >= diagram.range.start_row and row <= diagram.range.end_row then
+      return diagram
+    end
+  end
+  
+  return nil
+end
+
+---@param diagram Diagram
+---@param integrations Integration[]
+---@param renderer_options table<string, any>
+M.show_diagram_hover = function(diagram, integrations, renderer_options)
+  -- Find matching integration for current filetype
+  local bufnr = vim.api.nvim_get_current_buf()
+  local ft = vim.bo[bufnr].filetype
+  local integration = nil
+  for _, integ in ipairs(integrations) do
+    if vim.tbl_contains(integ.filetypes, ft) then
+      integration = integ
+      break
+    end
+  end
+  
+  if not integration then return end
+  
+  -- Find renderer
+  local renderer = nil
+  for _, r in ipairs(integration.renderers) do
+    if r.id == diagram.renderer_id then
+      renderer = r
+      break
+    end
+  end
+  
+  if not renderer then
+    vim.notify("No renderer found for " .. diagram.renderer_id, vim.log.levels.ERROR)
+    return
+  end
+  
+  -- Render the diagram
+  local options = renderer_options[renderer.id] or {}
+  local renderer_result = renderer.render(diagram.source, options)
+  
+  local function show_in_tab()
+    if vim.fn.filereadable(renderer_result.file_path) == 0 then
+      vim.notify("Diagram file not found: " .. renderer_result.file_path, vim.log.levels.ERROR)
+      return
+    end
+    
+    -- Create a new tab for better image.nvim support
+    vim.cmd("tabnew")
+    local buf = vim.api.nvim_get_current_buf()
+    local win = vim.api.nvim_get_current_win()
+    
+    -- Set buffer options
+    vim.api.nvim_buf_set_name(buf, diagram.renderer_id .. " diagram")
+    vim.bo[buf].buftype = "nofile"
+    vim.bo[buf].bufhidden = "wipe"
+    vim.bo[buf].swapfile = false
+    
+    -- Add header content
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      "# " .. diagram.renderer_id:upper() .. " Diagram",
+      "",
+      "Press 'q' to close this tab",
+      "Press 'o' to open image with system viewer",
+      "",
+    })
+    
+    -- Try to render the image
+    local image = image_nvim.from_file(renderer_result.file_path, {
+      buffer = buf,
+      window = win,
+      with_virtual_padding = true,
+      inline = true,
+      x = 0,
+      y = 5, -- Start after the header text
+    })
+    
+    if image then
+      image:render()
+    else
+      -- Fallback if image.nvim fails
+      vim.api.nvim_buf_set_lines(buf, -1, -1, false, {
+        "Image display failed. File: " .. renderer_result.file_path,
+      })
+    end
+    
+    -- Keymaps for the diagram tab
+    vim.keymap.set("n", "q", function()
+      if image then image:clear() end
+      vim.cmd("tabclose")
+    end, { buffer = buf, desc = "Close diagram tab" })
+    
+    vim.keymap.set("n", "<Esc>", function()
+      if image then image:clear() end
+      vim.cmd("tabclose")
+    end, { buffer = buf, desc = "Close diagram tab" })
+    
+    vim.keymap.set("n", "o", function()
+      vim.fn.system("open " .. vim.fn.shellescape(renderer_result.file_path))
+    end, { buffer = buf, desc = "Open image with system viewer" })
+  end
+  
+  if renderer_result.job_id then
+    -- Wait for async rendering
+    local timer = vim.loop.new_timer()
+    if not timer then return end
+    timer:start(0, 100, vim.schedule_wrap(function()
+      local result = vim.fn.jobwait({ renderer_result.job_id }, 0)
+      if result[1] ~= -1 then
+        if timer:is_active() then
+          timer:stop()
+        end
+        if not timer:is_closing() then
+          timer:close()
+          show_in_tab()
+        end
+      end
+    end))
+  else
+    show_in_tab()
+  end
+end
+
+---@param integrations Integration[]
+---@param renderer_options table<string, any>
+M.hover_at_cursor = function(integrations, renderer_options)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local diagram = get_diagram_at_cursor(bufnr, integrations)
+  
+  if not diagram then
+    vim.notify("No diagram found at cursor", vim.log.levels.INFO)
+    return
+  end
+  
+  M.show_diagram_hover(diagram, integrations, renderer_options)
+end
+
+return M

--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -2,6 +2,19 @@ local image_nvim = require("image")
 
 local M = {}
 
+local function show_loading_notification(diagram_type)
+  vim.notify("Loading " .. diagram_type .. " diagram...", vim.log.levels.INFO, { 
+    timeout = 5000 
+  })
+end
+
+local function show_ready_notification()
+  vim.notify("✓ Diagram ready", vim.log.levels.INFO, { 
+    replace = true,
+    timeout = 1500 
+  })
+end
+
 -- Helper function to calculate the full code block range from existing diagram data
 local get_extended_range = function(bufnr, diagram)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -108,6 +121,9 @@ M.show_diagram_hover = function(diagram, integrations, renderer_options)
       return
     end
     
+    -- Show ready notification to replace loading message
+    show_ready_notification()
+    
     -- Create a new tab for better image.nvim support
     vim.cmd("tabnew")
     local buf = vim.api.nvim_get_current_buf()
@@ -195,6 +211,7 @@ M.hover_at_cursor = function(integrations, renderer_options)
     return
   end
   
+  show_loading_notification(diagram.renderer_id)
   M.show_diagram_hover(diagram, integrations, renderer_options)
 end
 

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -119,7 +119,11 @@ local setup = function(opts)
   local current_ft = vim.bo[current_bufnr].filetype
 
   local setup_buffer = function(bufnr, integration)
-    -- render
+    -- render (only if events are configured)
+    if not state.events.render_buffer or #state.events.render_buffer == 0 then
+      return
+    end
+    
     vim.api.nvim_create_autocmd(state.events.render_buffer, {
       buffer = bufnr,
       callback = function(buf_ev)


### PR DESCRIPTION
## Summary

Add independent hover functionality for manual diagram viewing.

## Changes

### New Features
- **Independent hover module** (`lua/diagram/hover.lua`) with separated functionality
- **Cursor detection** - Works anywhere inside diagram code blocks
- **Manual diagram viewing** - Press `K` (or custom key) to open diagram in new tab

### Improvements
- **Fixed events configuration merging** - Properly respects `render_buffer = {}` to disable auto-rendering
- **Conditional first render** - Only renders on startup if events are configured
- **Better error handling** - Guard clauses prevent autocmd creation with empty events

### Architecture
- **Modular design** - Hover functionality completely independent from auto-rendering
- **Clean separation** - Core rendering logic untouched, hover as optional add-on
- **Extensible** - Easy to add more manual viewing features

## Usage

```lua
{
  "3rd/diagram.nvim",
  dependencies = {
    "3rd/image.nvim",
  },
  lazy = true,
  opts = {
    events = {
      render_buffer = {}, -- Disable auto-rendering
      clear_buffer = { "BufLeave" },
    },
  },
  keys = {
    {
      "K",
      function() require("diagram").show_diagram_hover() end,
      mode = "n",
      ft = { "markdown", "norg" },
      desc = "Show diagram in new tab",
    },
  },
}
```