### PR TITLE
Add a popup feature to display diagram image in a popup window

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,16 @@ With **lazy.nvim**:
         theme = nil, -- nil | "light" | "dark" | custom theme string
         cli_args = nil, -- nil | { "-p" } | { "-c", "config.plt" } | ...
       },
-    }
+    },
+    popup_options = {
+      enabled = false,        -- Enable popup preview (default: false)
+      auto_close = true,      -- Auto-close on cursor move (default: true)
+      auto_show = false,      -- Auto-show popup when cursor moves over diagram (default: false)
+      delay = 300,            -- Delay in ms before showing popup (default: 300)
+      width = nil,            -- Custom width (nil = auto)
+      height = nil,           -- Custom height (nil = auto)
+      border = "rounded",     -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
+    },
   },
 },
 ```
@@ -133,7 +142,8 @@ The plugin exposes the following API functions:
 
 - `setup(opts)`: Sets up the plugin with the given options.
 - `get_cache_dir()`: Returns the root cache directory.
-- `show_diagram_hover()`: Shows the diagram at cursor in a new tab (for manual keybinding).
+- `show_diagram_hover()`: Shows the diagram at cursor (popup or new tab based on configuration).
+- `close_popup()`: Manually closes any open popup window.
 
 ### Diagram Hover Feature
 
@@ -181,9 +191,75 @@ You can add a keymap to view diagrams in a dedicated tab. Place your cursor insi
 
 **Features:**
 - **Cursor detection**: Works when cursor is anywhere inside diagram code blocks
-- **New tab display**: Opens diagram in a dedicated tab with proper image rendering
+- **Multiple display modes**: Supports both popup windows and new tabs
 - **Multiple diagram types**: Supports mermaid, plantuml, d2, and gnuplot
 - **Easy navigation**:
-  - `q` or `Esc` to close the diagram tab
+  - `q` or `Esc` to close the diagram
   - `o` to open the image with system viewer (Preview, etc.)
 - **Async rendering**: Handles both cached and newly-rendered diagrams
+
+### Popup Preview Feature
+
+The plugin now supports popup window previews for diagrams, similar to image.nvim's popup feature for images. When enabled, diagrams will be displayed in a floating window at the cursor position.
+
+#### Basic Setup
+
+```lua
+require("diagram").setup({
+  popup_options = {
+    enabled = true,      -- Enable popup preview
+    auto_close = true,   -- Auto-close on cursor move
+    auto_show = false,   -- Manual trigger with keybinding (default)
+    border = "rounded",  -- Window border style
+  },
+})
+```
+
+#### Advanced Configuration
+
+```lua
+require("diagram").setup({
+  popup_options = {
+    enabled = true,        -- Enable popup preview
+    auto_close = true,     -- Auto-close on cursor move
+    auto_show = true,      -- Auto-show popup when cursor moves over diagram
+    delay = 300,           -- Delay in ms before showing popup (prevents flickering)
+    width = 60,            -- Custom width (columns)
+    height = 20,           -- Custom height (lines)
+    border = "rounded",    -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
+  },
+})
+```
+
+#### Display Mode Comparison
+
+**Popup Mode** (recommended for quick previews):
+- Shows diagram in a floating window at cursor position
+- Two trigger modes:
+  - **Auto-show** (recommended): Popup appears automatically when cursor moves over diagram
+  - **Manual trigger**: Press `K` to trigger popup display
+- Auto-closes when cursor moves away (configurable)
+- Perfect for quick diagram verification
+
+**Tab Mode** (default, for detailed viewing):
+- Opens diagram in a dedicated tab
+- Better for complex diagrams or长时间 viewing
+- Can be used alongside popup mode
+
+#### Key Features
+
+- **Smart positioning**: Popup appears at cursor position with proper offset
+- **Auto-sizing**: Automatically adjusts size based on actual image dimensions and terminal size
+  - **Smart scaling**: Converts image pixels to terminal cells for perfect fit
+  - **Aspect ratio preservation**: Maintains original diagram proportions
+  - **Size limits**: Prevents popup from exceeding 80% of terminal size
+- **Auto-cleanup**: Properly cleans up resources when closed
+- **Multiple trigger modes**:
+  - **Auto-show**: Popup appears automatically when cursor moves over diagram (with delay to prevent flickering)
+  - **Manual trigger**: Press `K` to show popup on demand
+- **Intelligent detection**: Only shows popup when cursor is inside diagram code blocks
+- **Multiple diagrams**: Supports all diagram types (mermaid, plantuml, d2, gnuplot)
+- **Flexible closing**:
+  - Auto-close on cursor move (default)
+  - Manual close with `q` or `Esc`
+  - Programmatic close with `require("diagram").close_popup()`

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Renderers take source code as input and render it to an image, often by calling 
 \
 Integrations read buffers, extract diagram code, and dispatch work to the renderers.
 
-| Integration | Supported renderers                          |
-| ----------- | ------------------------------------------- |
-| `markdown`  | `mermaid`, `plantuml`, `d2`, `gnuplot`      |
-| `neorg`     | `mermaid`, `plantuml`, `d2`, `gnuplot`      |
+| Integration | Supported renderers                    |
+| ----------- | -------------------------------------- |
+| `markdown`  | `mermaid`, `plantuml`, `d2`, `gnuplot` |
+| `neorg`     | `mermaid`, `plantuml`, `d2`, `gnuplot` |
 
 | Renderer   | Requirements                                      |
 | ---------- | ------------------------------------------------- |
@@ -89,6 +89,7 @@ You can pass custom command-line arguments to any renderer using the `cli_args` 
 **Common Use Cases:**
 
 1. **Fixing mmdc sandboxing issues (Nix/AppImage):**
+
    ```lua
    renderer_options = {
      mermaid = {
@@ -185,11 +186,13 @@ You can add a keymap to view diagrams in a dedicated tab. Place your cursor insi
 ```
 
 **Key Configuration Details:**
+
 - `"K"` - The key to press (can be changed to any key like `"<leader>d"`, `"gd"`, etc.)
 - `ft = { "markdown", "norg" }` - Only activates in markdown and neorg files
 - The function calls `require("diagram").show_diagram_hover()` to display the diagram
 
 **Features:**
+
 - **Cursor detection**: Works when cursor is anywhere inside diagram code blocks
 - **Multiple display modes**: Supports both popup windows and new tabs
 - **Multiple diagram types**: Supports mermaid, plantuml, d2, and gnuplot
@@ -197,69 +200,3 @@ You can add a keymap to view diagrams in a dedicated tab. Place your cursor insi
   - `q` or `Esc` to close the diagram
   - `o` to open the image with system viewer (Preview, etc.)
 - **Async rendering**: Handles both cached and newly-rendered diagrams
-
-### Popup Preview Feature
-
-The plugin now supports popup window previews for diagrams, similar to image.nvim's popup feature for images. When enabled, diagrams will be displayed in a floating window at the cursor position.
-
-#### Basic Setup
-
-```lua
-require("diagram").setup({
-  popup_options = {
-    enabled = true,      -- Enable popup preview
-    auto_close = true,   -- Auto-close on cursor move
-    auto_show = false,   -- Manual trigger with keybinding (default)
-    border = "rounded",  -- Window border style
-  },
-})
-```
-
-#### Advanced Configuration
-
-```lua
-require("diagram").setup({
-  popup_options = {
-    enabled = true,        -- Enable popup preview
-    auto_close = true,     -- Auto-close on cursor move
-    auto_show = true,      -- Auto-show popup when cursor moves over diagram
-    delay = 300,           -- Delay in ms before showing popup (prevents flickering)
-    width = 60,            -- Custom width (columns)
-    height = 20,           -- Custom height (lines)
-    border = "rounded",    -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
-  },
-})
-```
-
-#### Display Mode Comparison
-
-**Popup Mode** (recommended for quick previews):
-- Shows diagram in a floating window at cursor position
-- Two trigger modes:
-  - **Auto-show** (recommended): Popup appears automatically when cursor moves over diagram
-  - **Manual trigger**: Press `K` to trigger popup display
-- Auto-closes when cursor moves away (configurable)
-- Perfect for quick diagram verification
-
-**Tab Mode** (default, for detailed viewing):
-- Opens diagram in a dedicated tab
-- Better for complex diagrams or长时间 viewing
-- Can be used alongside popup mode
-
-#### Key Features
-
-- **Smart positioning**: Popup appears at cursor position with proper offset
-- **Auto-sizing**: Automatically adjusts size based on actual image dimensions and terminal size
-  - **Smart scaling**: Converts image pixels to terminal cells for perfect fit
-  - **Aspect ratio preservation**: Maintains original diagram proportions
-  - **Size limits**: Prevents popup from exceeding 80% of terminal size
-- **Auto-cleanup**: Properly cleans up resources when closed
-- **Multiple trigger modes**:
-  - **Auto-show**: Popup appears automatically when cursor moves over diagram (with delay to prevent flickering)
-  - **Manual trigger**: Press `K` to show popup on demand
-- **Intelligent detection**: Only shows popup when cursor is inside diagram code blocks
-- **Multiple diagrams**: Supports all diagram types (mermaid, plantuml, d2, gnuplot)
-- **Flexible closing**:
-  - Auto-close on cursor move (default)
-  - Manual close with `q` or `Esc`
-  - Programmatic close with `require("diagram").close_popup()`

--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -2,13 +2,13 @@ local image_nvim = require("image")
 
 local M = {}
 
-local function show_loading_notification(diagram_type)
+local show_loading_notification = function(diagram_type)
   vim.notify("Loading " .. diagram_type .. " diagram...", vim.log.levels.INFO, {
     timeout = 5000,
   })
 end
 
-local function show_ready_notification()
+local show_ready_notification = function()
   vim.notify("✓ Diagram ready", vim.log.levels.INFO, {
     replace = true,
     timeout = 1500,
@@ -78,10 +78,96 @@ local get_diagram_at_cursor = function(bufnr, integrations)
   return nil
 end
 
+--- Get the dimensions of an image file
+---@param file_path string
+---@return {width: number, height: number}|nil
+local get_image_dimensions = function(file_path)
+  -- Try using ImageMagick's identify command
+  local handle = io.popen(string.format('identify -format "%%w %%h" "%s" 2>/dev/null', file_path))
+  if handle then
+    local result = handle:read("*a")
+    handle:close()
+    if result and result:match("%d+%s+%d+") then
+      local width, height = result:match("(%d+)%s+(%d+)")
+      if width and height then
+        return {
+          width = tonumber(width),
+          height = tonumber(height),
+        }
+      end
+    end
+  end
+
+  -- Fallback: try to use image.lua to get dimensions
+  local success, image_module = pcall(require, "image")
+  if success and image_module then
+    local temp_image = image_module.from_file(file_path)
+    if temp_image and temp_image.image_width and temp_image.image_height then
+      local dims = {
+        width = temp_image.image_width,
+        height = temp_image.image_height,
+      }
+      temp_image:clear()
+      return dims
+    end
+  end
+
+  return nil
+end
+
+--- Calculate popup window size based on image dimensions
+---@param image_dims {width: number, height: number}|nil
+---@param popup_config table<string, any>
+---@return number popup_width
+---@return number popup_height
+local calculate_popup_size = function(image_dims, popup_config)
+  local term_size = require("image.utils.term").get_size()
+  local term_cols = term_size.screen_cols or 80
+  local term_rows = term_size.screen_rows or 24
+  local cell_width = term_size.cell_width or 10
+  local cell_height = term_size.cell_height or 20
+
+  -- Max size: 90% of terminal
+  local max_width = math.floor(term_cols * 0.9)
+  local max_height = math.floor(term_rows * 0.9)
+
+  if not image_dims then
+    -- Fallback: use half of window
+    return popup_config.width or math.floor(term_cols / 2),
+      popup_config.height or math.floor(term_rows / 2)
+  end
+
+  local image_math = require("image.utils.math")
+
+  -- Convert image pixels to terminal cells
+  local image_cols = math.floor(image_dims.width / cell_width)
+  local image_rows = math.floor(image_dims.height / cell_height)
+
+  -- Check if image exceeds max size
+  if image_cols > max_width or image_rows > max_height then
+    -- Scale down to fit, maintaining aspect ratio
+    if image_cols / max_width > image_rows / max_height then
+      -- Width is the limiting factor
+      return image_math.adjust_to_aspect_ratio(
+        term_size, image_dims.width, image_dims.height, max_width, 0
+      )
+    else
+      -- Height is the limiting factor
+      return image_math.adjust_to_aspect_ratio(
+        term_size, image_dims.width, image_dims.height, 0, max_height
+      )
+    end
+  end
+
+  -- Image fits, use its natural size
+  return image_cols, image_rows
+end
+
 ---@param diagram Diagram
 ---@param integrations Integration[]
 ---@param renderer_options table<string, any>
-M.show_diagram_hover = function(diagram, integrations, renderer_options)
+---@param popup_config table<string, any>
+M.show_diagram_hover = function(diagram, integrations, renderer_options, popup_config)
   -- Find matching integration for current filetype
   local bufnr = vim.api.nvim_get_current_buf()
   local ft = vim.bo[bufnr].filetype
@@ -112,6 +198,92 @@ M.show_diagram_hover = function(diagram, integrations, renderer_options)
   -- Render the diagram
   local options = renderer_options[renderer.id] or {}
   local renderer_result = renderer.render(diagram.source, options)
+
+  local function show_in_popup()
+    if vim.fn.filereadable(renderer_result.file_path) == 0 then
+      vim.notify("Diagram file not found: " .. renderer_result.file_path, vim.log.levels.ERROR)
+      return
+    end
+
+    show_ready_notification()
+
+    local image_dims = get_image_dimensions(renderer_result.file_path)
+    local popup_width, popup_height = calculate_popup_size(image_dims, popup_config)
+
+    -- Create a new buffer for the popup
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].filetype = "diagram_popup"
+    vim.bo[buf].bufhidden = "wipe"
+    vim.bo[buf].swapfile = false
+
+    -- Create the popup window
+    local win = vim.api.nvim_open_win(buf, false, {
+      relative = "cursor",
+      row = 1,
+      col = 0,
+      width = popup_width,
+      height = popup_height,
+      style = "minimal",
+      border = "single",
+    })
+
+    -- Create image
+    local image = image_nvim.from_file(renderer_result.file_path, {
+      buffer = buf,
+      window = win,
+      with_virtual_padding = false,
+      namespace = "diagram_popup",
+    })
+
+    if image then
+      image.ignore_global_max_size = true
+      -- Render after window is open (same as image.nvim)
+      vim.defer_fn(function()
+        if vim.api.nvim_win_is_valid(win) then
+          image:render({
+            x = 0,
+            y = 0,
+            width = popup_width,
+            height = popup_height,
+          })
+        end
+      end, 10)
+    else
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+        "Diagram: " .. diagram.renderer_id,
+        "",
+        "File: " .. renderer_result.file_path,
+        "",
+        "Image display failed in popup.",
+      })
+    end
+
+    -- Store popup data for cleanup
+    M._current_popup = {
+      window = win,
+      buffer = buf,
+      image = image,
+      auto_close = popup_config.auto_close ~= false,
+    }
+
+    -- Keymaps
+    vim.keymap.set("n", "q", function() M.close_popup() end, { buffer = buf, desc = "Close diagram popup" })
+    vim.keymap.set("n", "<Esc>", function() M.close_popup() end, { buffer = buf, desc = "Close diagram popup" })
+    vim.keymap.set("n", "o", function() vim.ui.open(renderer_result.file_path) end, { buffer = buf, desc = "Open image with system viewer" })
+
+    -- Auto-close on cursor move
+    if popup_config.auto_close ~= false then
+      vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+        callback = function()
+          if M._current_popup and vim.api.nvim_win_is_valid(M._current_popup.window) then
+            M.close_popup()
+          end
+        end,
+        once = true,
+        desc = "Auto-close diagram popup on cursor move",
+      })
+    end
+  end
 
   local function show_in_tab()
     if vim.fn.filereadable(renderer_result.file_path) == 0 then
@@ -190,19 +362,28 @@ M.show_diagram_hover = function(diagram, integrations, renderer_options)
           if timer:is_active() then timer:stop() end
           if not timer:is_closing() then
             timer:close()
-            show_in_tab()
+            if popup_config and popup_config.enabled then
+              show_in_popup()
+            else
+              show_in_tab()
+            end
           end
         end
       end)
     )
   else
-    show_in_tab()
+    if popup_config and popup_config.enabled then
+      show_in_popup()
+    else
+      show_in_tab()
+    end
   end
 end
 
 ---@param integrations Integration[]
 ---@param renderer_options table<string, any>
-M.hover_at_cursor = function(integrations, renderer_options)
+---@param popup_config table<string, any>
+M.hover_at_cursor = function(integrations, renderer_options, popup_config)
   local bufnr = vim.api.nvim_get_current_buf()
   local diagram = get_diagram_at_cursor(bufnr, integrations)
 
@@ -212,7 +393,40 @@ M.hover_at_cursor = function(integrations, renderer_options)
   end
 
   show_loading_notification(diagram.renderer_id)
-  M.show_diagram_hover(diagram, integrations, renderer_options)
+  M.show_diagram_hover(diagram, integrations, renderer_options, popup_config)
+end
+
+--- Close the current popup window
+M.close_popup = function()
+  if M._current_popup then
+    local popup = M._current_popup
+
+    -- Clear the image
+    if popup.image then
+      popup.image:clear()
+    end
+
+    -- Close the window
+    if vim.api.nvim_win_is_valid(popup.window) then
+      vim.api.nvim_win_close(popup.window, true)
+    end
+
+    -- Clear the buffer
+    if vim.api.nvim_buf_is_valid(popup.buffer) then
+      vim.api.nvim_buf_delete(popup.buffer, { force = true })
+    end
+
+    -- Reset the reference
+    M._current_popup = nil
+  end
+end
+
+--- Get the diagram at the current cursor position
+---@param bufnr number
+---@param integrations Integration[]
+---@return Diagram|nil
+M.get_diagram_at_cursor = function(bufnr, integrations)
+  return get_diagram_at_cursor(bufnr, integrations)
 end
 
 return M

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -36,6 +36,15 @@ local state = {
       cli_args = nil,
     },
   },
+  popup_options = {
+    enabled = false,        -- Enable popup preview
+    auto_close = true,      -- Auto-close on cursor move
+    auto_show = false,      -- Auto-show popup when cursor moves over diagram
+    delay = 300,            -- Delay in ms before showing popup (for auto_show)
+    width = nil,            -- Custom width (nil = auto)
+    height = nil,           -- Custom height (nil = auto)
+    border = "rounded",     -- Border style: "none", "single", "double", "rounded", "solid", "shadow"
+  },
   integrations = {
     integrations.markdown,
     integrations.neorg,
@@ -128,7 +137,7 @@ end
 ---@param opts PluginOptions
 local setup = function(opts)
   local ok = pcall(require, "image")
-  if not ok then 
+  if not ok then
     vim.notify("Missing dependency: 3rd/image.nvim\nPlease install image.nvim to use diagram.nvim", vim.log.levels.ERROR, { title = "Diagram.nvim" })
     return
   end
@@ -136,10 +145,15 @@ local setup = function(opts)
   state.integrations = opts.integrations or state.integrations
   state.events = vim.tbl_deep_extend("force", state.events, opts.events or {})
   state.renderer_options = vim.tbl_deep_extend("force", state.renderer_options, opts.renderer_options or {})
+  state.popup_options = vim.tbl_deep_extend("force", state.popup_options, opts.popup_options or {})
 
   local current_bufnr = vim.api.nvim_get_current_buf()
   local current_winnr = vim.api.nvim_get_current_win()
   local current_ft = vim.bo[current_bufnr].filetype
+
+  -- Track popup auto-show state
+  local popup_timer = nil
+  local last_diagram = nil
 
   local setup_buffer = function(bufnr, integration)
     -- render (only if events are configured)
@@ -159,6 +173,64 @@ local setup = function(opts)
         buffer = bufnr,
         callback = function()
           clear_buffer(bufnr)
+        end,
+      })
+    end
+
+    -- Setup auto-show popup on cursor move
+    if state.popup_options.enabled and state.popup_options.auto_show then
+      vim.api.nvim_create_autocmd("CursorMoved", {
+        buffer = bufnr,
+        callback = function()
+          -- Cancel previous timer
+          if popup_timer then
+            popup_timer:stop()
+            popup_timer:close()
+            popup_timer = nil
+          end
+
+          -- Check if cursor is over a diagram
+          local diagram = require("diagram.hover").get_diagram_at_cursor(bufnr, state.integrations)
+
+          if diagram then
+            -- If we moved to a different diagram, close the current popup
+            if last_diagram and (
+              last_diagram.range.start_row ~= diagram.range.start_row or
+              last_diagram.range.start_col ~= diagram.range.start_col
+            ) then
+              require("diagram.hover").close_popup()
+            end
+
+            last_diagram = diagram
+
+            -- Show popup after delay
+            popup_timer = vim.loop.new_timer()
+            if popup_timer then
+              popup_timer:start(
+                state.popup_options.delay or 300,
+                0,
+                vim.schedule_wrap(function()
+                  popup_timer:close()
+                  popup_timer = nil
+
+                  -- Check if we're still over the same diagram
+                  local current_diagram = require("diagram.hover").get_diagram_at_cursor(bufnr, state.integrations)
+                  if current_diagram and last_diagram and (
+                    current_diagram.range.start_row == last_diagram.range.start_row and
+                    current_diagram.range.start_col == last_diagram.range.start_col
+                  ) then
+                    require("diagram.hover").show_diagram_hover(current_diagram, state.integrations, state.renderer_options, state.popup_options)
+                  end
+                end)
+              )
+            end
+          else
+            -- Not over a diagram, close popup if auto_close is enabled
+            if state.popup_options.auto_close then
+              require("diagram.hover").close_popup()
+            end
+            last_diagram = nil
+          end
         end,
       })
     end
@@ -193,11 +265,12 @@ local get_cache_dir = function()
 end
 
 local show_diagram_hover = function()
-  hover.hover_at_cursor(state.integrations, state.renderer_options)
+  hover.hover_at_cursor(state.integrations, state.renderer_options, state.popup_options)
 end
 
 return {
   setup = setup,
   get_cache_dir = get_cache_dir,
   show_diagram_hover = show_diagram_hover,
+  close_popup = hover.close_popup,
 }


### PR DESCRIPTION
Hi! I hope you're doing well. Great work on this plugin – it's been really helpful for me!

I noticed that your image.nvim plugin includes a popup feature, while diagram.nvim currently doesn't have one. I've implemented this functionality and would greatly appreciate it if you could review this PR.

Implementation highlights:

Added a popup feature for displaying diagrams
The popup window automatically detects the current buffer's window size and adapts accordingly for optimal viewing
Thank you for your time and consideration!

Thx! 

Just like this 
<img width="418" height="399" alt="image" src="https://github.com/user-attachments/assets/3e113b6b-a71a-47e4-9005-95fd21e8d61a" />
