### PR TITLE
fix: critical security fixes, cache invalidation & modernization

### DIFF
--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -3,216 +3,219 @@ local image_nvim = require("image")
 local M = {}
 
 local function show_loading_notification(diagram_type)
-  vim.notify("Loading " .. diagram_type .. " diagram...", vim.log.levels.INFO, {
-    timeout = 5000,
-  })
+	vim.notify("Loading " .. diagram_type .. " diagram...", vim.log.levels.INFO, {
+		timeout = 5000,
+	})
 end
 
 local function show_ready_notification()
-  vim.notify("✓ Diagram ready", vim.log.levels.INFO, {
-    replace = true,
-    timeout = 1500,
-  })
+	vim.notify("✓ Diagram ready", vim.log.levels.INFO, {
+		replace = true,
+		timeout = 1500,
+	})
 end
 
 -- Helper function to calculate the full code block range from existing diagram data
 local get_extended_range = function(bufnr, diagram)
-  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local start_row = diagram.range.start_row
-  local end_row = diagram.range.end_row
+	local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+	local start_row = diagram.range.start_row
+	local end_row = diagram.range.end_row
 
-  -- Look backwards from start_row to find the opening ```
-  for i = start_row, 0, -1 do
-    local line = lines[i + 1] -- Lua is 1-indexed, TreeSitter is 0-indexed
-    if line and line:match("^%s*```") then
-      start_row = i
-      break
-    end
-  end
+	-- Look backwards from start_row to find the opening ```
+	for i = start_row, 0, -1 do
+		local line = lines[i + 1] -- Lua is 1-indexed, TreeSitter is 0-indexed
+		if line and line:match("^%s*```") then
+			start_row = i
+			break
+		end
+	end
 
-  -- Look forwards to find the closing ```
-  for i = end_row, #lines - 1 do
-    local line = lines[i + 1] -- Lua is 1-indexed, TreeSitter is 0-indexed
-    if line and line:match("^%s*```%s*$") then
-      end_row = i
-      break
-    end
-  end
+	-- Look forwards to find the closing ```
+	for i = end_row, #lines - 1 do
+		local line = lines[i + 1] -- Lua is 1-indexed, TreeSitter is 0-indexed
+		if line and line:match("^%s*```%s*$") then
+			end_row = i
+			break
+		end
+	end
 
-  return {
-    start_row = start_row,
-    start_col = 0,
-    end_row = end_row,
-    end_col = 0,
-  }
+	return {
+		start_row = start_row,
+		start_col = 0,
+		end_row = end_row,
+		end_col = 0,
+	}
 end
 
 ---@param bufnr number
 ---@param integrations Integration[]
 ---@return Diagram|nil
 local get_diagram_at_cursor = function(bufnr, integrations)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local row = cursor[1] - 1 -- 0-indexed
-  local col = cursor[2]
+	local cursor = vim.api.nvim_win_get_cursor(0)
+	local row = cursor[1] - 1 -- 0-indexed
+	local col = cursor[2]
 
-  -- Find matching integration for current filetype
-  local ft = vim.bo[bufnr].filetype
-  local integration = nil
-  for _, integ in ipairs(integrations) do
-    if vim.tbl_contains(integ.filetypes, ft) then
-      integration = integ
-      break
-    end
-  end
+	-- Find matching integration for current filetype
+	local ft = vim.bo[bufnr].filetype
+	local integration = nil
+	for _, integ in ipairs(integrations) do
+		if vim.tbl_contains(integ.filetypes, ft) then
+			integration = integ
+			break
+		end
+	end
 
-  if not integration then return nil end
+	if not integration then
+		return nil
+	end
 
-  local diagrams = integration.query_buffer_diagrams(bufnr)
-  for _, diagram in ipairs(diagrams) do
-    -- Expand the detection range to include the entire code block
-    local extended_range = get_extended_range(bufnr, diagram)
+	local diagrams = integration.query_buffer_diagrams(bufnr)
+	for _, diagram in ipairs(diagrams) do
+		-- Expand the detection range to include the entire code block
+		local extended_range = get_extended_range(bufnr, diagram)
 
-    if row >= extended_range.start_row and row <= extended_range.end_row then return diagram end
-  end
+		if row >= extended_range.start_row and row <= extended_range.end_row then
+			return diagram
+		end
+	end
 
-  return nil
+	return nil
 end
 
 ---@param diagram Diagram
 ---@param integrations Integration[]
 ---@param renderer_options table<string, any>
 M.show_diagram_hover = function(diagram, integrations, renderer_options)
-  -- Find matching integration for current filetype
-  local bufnr = vim.api.nvim_get_current_buf()
-  local ft = vim.bo[bufnr].filetype
-  local integration = nil
-  for _, integ in ipairs(integrations) do
-    if vim.tbl_contains(integ.filetypes, ft) then
-      integration = integ
-      break
-    end
-  end
+	-- Find matching integration for current filetype
+	local bufnr = vim.api.nvim_get_current_buf()
+	local ft = vim.bo[bufnr].filetype
+	local integration = nil
+	for _, integ in ipairs(integrations) do
+		if vim.tbl_contains(integ.filetypes, ft) then
+			integration = integ
+			break
+		end
+	end
 
-  if not integration then return end
+	if not integration then
+		return
+	end
 
-  -- Find renderer
-  local renderer = nil
-  for _, r in ipairs(integration.renderers) do
-    if r.id == diagram.renderer_id then
-      renderer = r
-      break
-    end
-  end
+	-- Find renderer
+	local renderer = nil
+	for _, r in ipairs(integration.renderers) do
+		if r.id == diagram.renderer_id then
+			renderer = r
+			break
+		end
+	end
 
-  if not renderer then
-    vim.notify("No renderer found for " .. diagram.renderer_id, vim.log.levels.ERROR)
-    return
-  end
+	if not renderer then
+		vim.notify("No renderer found for " .. diagram.renderer_id, vim.log.levels.ERROR)
+		return
+	end
 
-  -- Render the diagram
-  local options = renderer_options[renderer.id] or {}
-  local renderer_result = renderer.render(diagram.source, options)
+	-- Render the diagram
+	local options = renderer_options[renderer.id] or {}
+	local renderer_result
 
-  local function show_in_tab()
-    if vim.fn.filereadable(renderer_result.file_path) == 0 then
-      vim.notify("Diagram file not found: " .. renderer_result.file_path, vim.log.levels.ERROR)
-      return
-    end
+	local function show_in_tab()
+		if not renderer_result or vim.fn.filereadable(renderer_result.file_path) == 0 then
+			vim.notify(
+				"Diagram file not found: " .. (renderer_result and renderer_result.file_path or "nil"),
+				vim.log.levels.ERROR
+			)
+			return
+		end
 
-    -- Show ready notification to replace loading message
-    show_ready_notification()
+		-- Show ready notification to replace loading message
+		show_ready_notification()
 
-    -- Create a new tab for better image.nvim support
-    vim.cmd("tabnew")
-    local buf = vim.api.nvim_get_current_buf()
-    local win = vim.api.nvim_get_current_win()
+		-- Create a new tab for better image.nvim support
+		vim.cmd("tabnew")
+		local buf = vim.api.nvim_get_current_buf()
+		local win = vim.api.nvim_get_current_win()
 
-    -- Set buffer options
-    vim.api.nvim_buf_set_name(buf, diagram.renderer_id .. " diagram")
-    vim.bo[buf].buftype = "nofile"
-    vim.bo[buf].bufhidden = "wipe"
-    vim.bo[buf].swapfile = false
+		-- Set buffer options
+		vim.api.nvim_buf_set_name(buf, diagram.renderer_id .. " diagram")
+		vim.bo[buf].buftype = "nofile"
+		vim.bo[buf].bufhidden = "wipe"
+		vim.bo[buf].swapfile = false
 
-    -- Add header content
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
-      "# " .. diagram.renderer_id:upper() .. " Diagram",
-      "",
-      "Press 'q' to close this tab",
-      "Press 'o' to open image with system viewer",
-      "",
-    })
+		-- Add header content
+		vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+			"# " .. diagram.renderer_id:upper() .. " Diagram",
+			"",
+			"Press 'q' to close this tab",
+			"Press 'o' to open image with system viewer",
+			"",
+		})
 
-    -- Try to render the image
-    local image = image_nvim.from_file(renderer_result.file_path, {
-      buffer = buf,
-      window = win,
-      with_virtual_padding = true,
-      inline = true,
-      x = 0,
-      y = 5, -- Start after the header text
-    })
+		-- Try to render the image
+		local image = image_nvim.from_file(renderer_result.file_path, {
+			buffer = buf,
+			window = win,
+			with_virtual_padding = true,
+			inline = true,
+			x = 0,
+			y = 5, -- Start after the header text
+		})
 
-    if image then
-      image:render()
-    else
-      -- Fallback if image.nvim fails
-      vim.api.nvim_buf_set_lines(buf, -1, -1, false, {
-        "Image display failed. File: " .. renderer_result.file_path,
-      })
-    end
+		if image then
+			image:render()
+		else
+			-- Fallback if image.nvim fails
+			vim.api.nvim_buf_set_lines(buf, -1, -1, false, {
+				"Image display failed. File: " .. renderer_result.file_path,
+			})
+		end
 
-    -- Keymaps for the diagram tab
-    vim.keymap.set("n", "q", function()
-      if image then image:clear() end
-      vim.cmd("tabclose")
-    end, { buffer = buf, desc = "Close diagram tab" })
+		-- Keymaps for the diagram tab
+		vim.keymap.set("n", "q", function()
+			if image then
+				image:clear()
+			end
+			vim.cmd("tabclose")
+		end, { buffer = buf, desc = "Close diagram tab" })
 
-    vim.keymap.set("n", "<Esc>", function()
-      if image then image:clear() end
-      vim.cmd("tabclose")
-    end, { buffer = buf, desc = "Close diagram tab" })
+		vim.keymap.set("n", "<Esc>", function()
+			if image then
+				image:clear()
+			end
+			vim.cmd("tabclose")
+		end, { buffer = buf, desc = "Close diagram tab" })
 
-    vim.keymap.set("n", "o", function()
-      vim.ui.open(renderer_result.file_path)
-    end, { buffer = buf, desc = "Open image with system viewer" })
-  end
+		vim.keymap.set("n", "o", function()
+			vim.ui.open(renderer_result.file_path)
+		end, { buffer = buf, desc = "Open image with system viewer" })
+	end
 
-  if renderer_result.job_id then
-    -- Wait for async rendering
-    local timer = vim.loop.new_timer()
-    if not timer then return end
-    timer:start(
-      0,
-      100,
-      vim.schedule_wrap(function()
-        local result = vim.fn.jobwait({ renderer_result.job_id }, 0)
-        if result[1] ~= -1 then
-          if timer:is_active() then timer:stop() end
-          if not timer:is_closing() then
-            timer:close()
-            show_in_tab()
-          end
-        end
-      end)
-    )
-  else
-    show_in_tab()
-  end
+	renderer_result = renderer.render(diagram.source, options, function()
+		vim.schedule(show_in_tab)
+	end)
+
+	if not renderer_result then
+		return
+	end
+
+	if not renderer_result.job_id then
+		show_in_tab()
+	end
 end
 
 ---@param integrations Integration[]
 ---@param renderer_options table<string, any>
 M.hover_at_cursor = function(integrations, renderer_options)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local diagram = get_diagram_at_cursor(bufnr, integrations)
+	local bufnr = vim.api.nvim_get_current_buf()
+	local diagram = get_diagram_at_cursor(bufnr, integrations)
 
-  if not diagram then
-    vim.notify("No diagram found at cursor", vim.log.levels.INFO)
-    return
-  end
+	if not diagram then
+		vim.notify("No diagram found at cursor", vim.log.levels.INFO)
+		return
+	end
 
-  show_loading_notification(diagram.renderer_id)
-  M.show_diagram_hover(diagram, integrations, renderer_options)
+	show_loading_notification(diagram.renderer_id)
+	M.show_diagram_hover(diagram, integrations, renderer_options)
 end
 
 return M

--- a/lua/diagram/init.lua
+++ b/lua/diagram/init.lua
@@ -4,222 +4,224 @@ local integrations = require("diagram/integrations")
 
 ---@class State
 local state = {
-  events = {
-    render_buffer = { "InsertLeave", "BufWinEnter", "TextChanged" },
-    clear_buffer = { "BufLeave" },
-  },
-  renderer_options = {
-    mermaid = {
-      background = nil,
-      theme = nil,
-      scale = nil,
-      width = nil,
-      height = nil,
-      cli_args = nil,
-    },
-    plantuml = {
-      charset = nil,
-      cli_args = nil,
-    },
-    d2 = {
-      theme_id = nil,
-      dark_theme_id = nil,
-      scale = nil,
-      layout = nil,
-      sketch = nil,
-      cli_args = nil,
-    },
-    gnuplot = {
-      size = nil,
-      font = nil,
-      theme = nil,
-      cli_args = nil,
-    },
-  },
-  integrations = {
-    integrations.markdown,
-    integrations.neorg,
-  },
-  diagrams = {},
+	events = {
+		render_buffer = { "InsertLeave", "BufWinEnter", "TextChanged" },
+		clear_buffer = { "BufLeave" },
+	},
+	renderer_options = {
+		mermaid = {
+			background = nil,
+			theme = nil,
+			scale = nil,
+			width = nil,
+			height = nil,
+			cli_args = nil,
+		},
+		plantuml = {
+			charset = nil,
+			cli_args = nil,
+		},
+		d2 = {
+			theme_id = nil,
+			dark_theme_id = nil,
+			scale = nil,
+			layout = nil,
+			sketch = nil,
+			cli_args = nil,
+		},
+		gnuplot = {
+			size = nil,
+			font = nil,
+			theme = nil,
+			cli_args = nil,
+		},
+	},
+	integrations = {
+		integrations.markdown,
+		integrations.neorg,
+	},
+	diagrams = {},
 }
 
 local clear_buffer = function(bufnr)
-  for _, diagram in ipairs(state.diagrams) do
-    if diagram.bufnr == bufnr and diagram.image ~= nil then diagram.image:clear() end
-  end
+	for _, diagram in ipairs(state.diagrams) do
+		if diagram.bufnr == bufnr and diagram.image ~= nil then
+			diagram.image:clear()
+		end
+	end
 end
 
 ---@param bufnr number
 ---@param winnr number
 ---@param integration Integration
 local render_buffer = function(bufnr, winnr, integration)
-  local diagrams = integration.query_buffer_diagrams(bufnr)
-  clear_buffer(bufnr)
-  for _, diagram in ipairs(diagrams) do
-    ---@type Renderer
-    local renderer = nil
-    for _, r in ipairs(integration.renderers) do
-      if r.id == diagram.renderer_id then
-        renderer = r
-        break
-      end
-    end
-    if not renderer then
-      vim.notify("Unknown diagram renderer: " .. diagram.renderer_id, vim.log.levels.ERROR, { title = "Diagram.nvim" })
-      goto continue
-    end
+	local diagrams = integration.query_buffer_diagrams(bufnr)
+	clear_buffer(bufnr)
+	for _, diagram in ipairs(diagrams) do
+		---@type Renderer
+		local renderer = nil
+		for _, r in ipairs(integration.renderers) do
+			if r.id == diagram.renderer_id then
+				renderer = r
+				break
+			end
+		end
+		if not renderer then
+			vim.notify(
+				"Unknown diagram renderer: " .. diagram.renderer_id,
+				vim.log.levels.ERROR,
+				{ title = "Diagram.nvim" }
+			)
+			goto continue
+		end
 
-    local renderer_options = state.renderer_options[renderer.id] or {}
-    local renderer_result = renderer.render(diagram.source, renderer_options)
-    
-    -- Skip rendering if the renderer returned nil (e.g., executable not found)
-    if not renderer_result then
-      goto continue
-    end
+		local renderer_options = state.renderer_options[renderer.id] or {}
+		local renderer_result
 
-    local function render_image()
-      if vim.fn.filereadable(renderer_result.file_path) == 0 then return end
+		local function render_image()
+			if not renderer_result or vim.fn.filereadable(renderer_result.file_path) == 0 then
+				return
+			end
 
-      local diagram_col = diagram.range.start_col
-      local diagram_row = diagram.range.start_row
-      if vim.bo[bufnr].filetype == "norg" then diagram_row = diagram_row - 1 end
+			local diagram_col = diagram.range.start_col
+			local diagram_row = diagram.range.start_row
+			if vim.bo[bufnr].filetype == "norg" then
+				diagram_row = diagram_row - 1
+			end
 
-      local image = image_nvim.from_file(renderer_result.file_path, {
-        buffer = bufnr,
-        window = winnr,
-        with_virtual_padding = true,
-        inline = true,
-        x = diagram_col,
-        y = diagram_row,
-        render_offset_top = 1,
-      })
-      diagram.image = image
+			local image = image_nvim.from_file(renderer_result.file_path, {
+				buffer = bufnr,
+				window = winnr,
+				with_virtual_padding = true,
+				inline = true,
+				x = diagram_col,
+				y = diagram_row,
+				render_offset_top = 1,
+			})
+			diagram.image = image
 
-      table.insert(state.diagrams, diagram)
-      image:render()
-    end
+			table.insert(state.diagrams, diagram)
+			image:render()
+		end
 
-    if renderer_result.job_id then
-      -- Use a timer to poll the job's completion status every 100ms.
-      local timer = vim.loop.new_timer()
-      if not timer then return end
-      timer:start(
-        0,
-        100,
-        vim.schedule_wrap(function()
-          local result = vim.fn.jobwait({ renderer_result.job_id }, 0)
-          if result[1] ~= -1 then
-            if timer:is_active() then timer:stop() end
-            if not timer:is_closing() then
-              timer:close()
-              render_image()
-            end
-          end
-        end)
-      )
-    else
-      render_image()
-    end
-    
-    ::continue::
-  end
+		renderer_result = renderer.render(diagram.source, renderer_options, function()
+			vim.schedule(render_image)
+		end)
+
+		-- Skip rendering if the renderer returned nil (e.g., executable not found)
+		if not renderer_result then
+			goto continue
+		end
+
+		if not renderer_result.job_id then
+			render_image()
+		end
+
+		::continue::
+	end
 end
 
 ---@param opts PluginOptions
 local setup = function(opts)
-  local ok = pcall(require, "image")
-  if not ok then 
-    vim.notify("Missing dependency: 3rd/image.nvim\nPlease install image.nvim to use diagram.nvim", vim.log.levels.ERROR, { title = "Diagram.nvim" })
-    return
-  end
+	local ok = pcall(require, "image")
+	if not ok then
+		vim.notify(
+			"Missing dependency: 3rd/image.nvim\nPlease install image.nvim to use diagram.nvim",
+			vim.log.levels.ERROR,
+			{ title = "Diagram.nvim" }
+		)
+		return
+	end
 
-  state.integrations = opts.integrations or state.integrations
-  if opts.events then
-    for k, v in pairs(opts.events) do
-      state.events[k] = v
-    end
-  end
-  state.renderer_options = vim.tbl_deep_extend("force", state.renderer_options, opts.renderer_options or {})
+	state.integrations = opts.integrations or state.integrations
+	if opts.events then
+		for k, v in pairs(opts.events) do
+			state.events[k] = v
+		end
+	end
+	state.renderer_options = vim.tbl_deep_extend("force", state.renderer_options, opts.renderer_options or {})
 
-  local current_bufnr = vim.api.nvim_get_current_buf()
-  local current_winnr = vim.api.nvim_get_current_win()
-  local current_ft = vim.bo[current_bufnr].filetype
+	local current_bufnr = vim.api.nvim_get_current_buf()
+	local current_winnr = vim.api.nvim_get_current_win()
+	local current_ft = vim.bo[current_bufnr].filetype
 
-  local setup_buffer = function(bufnr, integration)
-    -- render (only if events are configured)
-    if not state.events.render_buffer or #state.events.render_buffer == 0 then return end
+	local setup_buffer = function(bufnr, integration)
+		-- render (only if events are configured)
+		if not state.events.render_buffer or #state.events.render_buffer == 0 then
+			return
+		end
 
-    vim.api.nvim_create_autocmd(state.events.render_buffer, {
-      buffer = bufnr,
-      callback = function(buf_ev)
-        local winnr = buf_ev.event == "BufWinEnter" and buf_ev.winnr or vim.api.nvim_get_current_win()
-        render_buffer(bufnr, winnr, integration)
-      end,
-    })
+		vim.api.nvim_create_autocmd(state.events.render_buffer, {
+			buffer = bufnr,
+			callback = function(buf_ev)
+				local winnr = buf_ev.event == "BufWinEnter" and buf_ev.winnr or vim.api.nvim_get_current_win()
+				render_buffer(bufnr, winnr, integration)
+			end,
+		})
 
-    -- clear
-    if state.events.clear_buffer and #state.events.clear_buffer > 0 then
-      vim.api.nvim_create_autocmd(state.events.clear_buffer, {
-        buffer = bufnr,
-        callback = function()
-          clear_buffer(bufnr)
-        end,
-      })
-    end
-  end
+		-- clear
+		if state.events.clear_buffer and #state.events.clear_buffer > 0 then
+			vim.api.nvim_create_autocmd(state.events.clear_buffer, {
+				buffer = bufnr,
+				callback = function()
+					clear_buffer(bufnr)
+				end,
+			})
+		end
+	end
 
-  -- setup integrations
-  for _, integration in ipairs(state.integrations) do
-    vim.api.nvim_create_autocmd("FileType", {
-      pattern = integration.filetypes,
-      callback = function(ft_event)
-        setup_buffer(ft_event.buf, integration)
-      end,
-    })
+	-- setup integrations
+	for _, integration in ipairs(state.integrations) do
+		vim.api.nvim_create_autocmd("FileType", {
+			pattern = integration.filetypes,
+			callback = function(ft_event)
+				setup_buffer(ft_event.buf, integration)
+			end,
+		})
 
-    -- first render (only if render events are enabled)
-    if
-      vim.tbl_contains(integration.filetypes, current_ft)
-      and state.events.render_buffer
-      and #state.events.render_buffer > 0
-    then
-      setup_buffer(current_bufnr, integration)
-      render_buffer(current_bufnr, current_winnr, integration)
-    elseif vim.tbl_contains(integration.filetypes, current_ft) then
-      -- Still setup buffer for potential hover usage but don't auto-render
-      setup_buffer(current_bufnr, integration)
-    end
-  end
+		-- first render (only if render events are enabled)
+		if
+			vim.tbl_contains(integration.filetypes, current_ft)
+			and state.events.render_buffer
+			and #state.events.render_buffer > 0
+		then
+			setup_buffer(current_bufnr, integration)
+			render_buffer(current_bufnr, current_winnr, integration)
+		elseif vim.tbl_contains(integration.filetypes, current_ft) then
+			-- Still setup buffer for potential hover usage but don't auto-render
+			setup_buffer(current_bufnr, integration)
+		end
+	end
 end
 
 local get_cache_dir = function()
-  return vim.fn.stdpath("cache") .. "/diagram-cache"
+	return vim.fn.stdpath("cache") .. "/diagram-cache"
 end
 
 local show_diagram_hover = function()
-  hover.hover_at_cursor(state.integrations, state.renderer_options)
+	hover.hover_at_cursor(state.integrations, state.renderer_options)
 end
 
 local render = function()
-  local bufnr = vim.api.nvim_get_current_buf()
-  local winnr = vim.api.nvim_get_current_win()
-  local ft = vim.bo[bufnr].filetype
-  for _, integration in ipairs(state.integrations) do
-    if vim.tbl_contains(integration.filetypes, ft) then
-      render_buffer(bufnr, winnr, integration)
-      return
-    end
-  end
+	local bufnr = vim.api.nvim_get_current_buf()
+	local winnr = vim.api.nvim_get_current_win()
+	local ft = vim.bo[bufnr].filetype
+	for _, integration in ipairs(state.integrations) do
+		if vim.tbl_contains(integration.filetypes, ft) then
+			render_buffer(bufnr, winnr, integration)
+			return
+		end
+	end
 end
 
 local clear = function()
-  clear_buffer(vim.api.nvim_get_current_buf())
+	clear_buffer(vim.api.nvim_get_current_buf())
 end
 
 return {
-  setup = setup,
-  get_cache_dir = get_cache_dir,
-  show_diagram_hover = show_diagram_hover,
-  render = render,
-  clear = clear,
+	setup = setup,
+	get_cache_dir = get_cache_dir,
+	show_diagram_hover = show_diagram_hover,
+	render = render,
+	clear = clear,
 }

--- a/lua/diagram/integrations/markdown.lua
+++ b/lua/diagram/integrations/markdown.lua
@@ -1,73 +1,73 @@
 local renderers = require("diagram/renderers")
-local ts_query = require("vim.treesitter.query")
 
 ---@type vim.treesitter.Query
 local query = nil
 
 ---@class Integration
 local M = {
-  id = "markdown",
-  filetypes = { "markdown" },
-  renderers = {
-    renderers.mermaid,
-    renderers.plantuml,
-    renderers.d2,
-    renderers.gnuplot,
-  },
+	id = "markdown",
+	filetypes = { "markdown" },
+	renderers = {
+		renderers.mermaid,
+		renderers.plantuml,
+		renderers.d2,
+		renderers.gnuplot,
+	},
 }
 
 M.query_buffer_diagrams = function(bufnr)
-  if not query then
-    query = ts_query.parse("markdown", "(fenced_code_block (info_string) @info (code_fence_content) @code)")
-  end
+	if not query then
+		query =
+			vim.treesitter.query.parse("markdown", "(fenced_code_block (info_string) @info (code_fence_content) @code)")
+	end
 
-  local buf = bufnr or vim.api.nvim_get_current_buf()
-  local parser = vim.treesitter.get_parser(buf, "markdown")
-  parser:parse(true)
+	local buf = bufnr or vim.api.nvim_get_current_buf()
+	local parser = vim.treesitter.get_parser(buf, "markdown")
+	parser:parse(true)
 
-  local root = parser:parse()[1]:root()
-  local matches = query:iter_captures(root, bufnr)
+	local root = parser:parse()[1]:root()
+	local matches = query:iter_captures(root, bufnr)
 
-  ---@type Diagram[]
-  local diagrams = {}
-  local current_language = nil
-  ---@type { start_row: number, start_col: number, end_row: number, end_col: number }
-  local current_range = nil
-  for id, node in matches do
-    local key = query.captures[id]
-    local value = vim.treesitter.get_node_text(node, bufnr)
-    if node:parent():parent() and node:parent():parent():type() == "block_quote" then
-      value = value:gsub("\n>", "\n"):gsub("^>", "")
-    end
+	---@type Diagram[]
+	local diagrams = {}
+	local current_language = nil
+	---@type { start_row: number, start_col: number, end_row: number, end_col: number }
+	local current_range = nil
+	for id, node in matches do
+		local key = query.captures[id]
+		local value = vim.treesitter.get_node_text(node, bufnr)
+		if node:parent():parent() and node:parent():parent():type() == "block_quote" then
+			value = value:gsub("\n>", "\n"):gsub("^>", "")
+		end
 
-    if key == "info" then
-      ---@diagnostic disable-next-line: unused-local
-      local start_row, _start_col, end_row, end_col = node:range()
-      current_range = {
-        start_row = start_row,
-        start_col = 0,
-        end_row = end_row,
-        end_col = end_col,
-      }
-      current_language = value
-    else
-      if
-        current_language == "mermaid"
-        or current_language == "plantuml"
-        or current_language == "d2"
-        or current_language == "gnuplot"
-      then
-        table.insert(diagrams, {
-          bufnr = bufnr,
-          renderer_id = current_language,
-          source = value,
-          range = current_range,
-        })
-      end
-    end
-  end
+		if key == "info" then
+			---@diagnostic disable-next-line: unused-local
+			local start_row, _start_col, end_row, end_col = node:range()
+			current_range = {
+				start_row = start_row,
+				start_col = 0,
+				end_row = end_row,
+				end_col = end_col,
+			}
+			current_language = value
+		else
+			if
+				current_language == "mermaid"
+				or current_language == "plantuml"
+				or current_language == "d2"
+				or current_language == "gnuplot"
+			then
+				table.insert(diagrams, {
+					bufnr = bufnr,
+					renderer_id = current_language,
+					source = value,
+					range = current_range,
+				})
+			end
+		end
+	end
 
-  return diagrams
+	return diagrams
 end
 
 return M

--- a/lua/diagram/integrations/neorg.lua
+++ b/lua/diagram/integrations/neorg.lua
@@ -1,83 +1,83 @@
 local renderers = require("diagram/renderers")
-local ts_query = require("vim.treesitter.query")
 
 ---@type vim.treesitter.Query
 local query = nil
 
 ---@class Integration
 local M = {
-  id = "neorg",
-  filetypes = { "norg" },
-  renderers = {
-    renderers.mermaid,
-    renderers.plantuml,
-    renderers.d2,
-    renderers.gnuplot,
-  },
+	id = "neorg",
+	filetypes = { "norg" },
+	renderers = {
+		renderers.mermaid,
+		renderers.plantuml,
+		renderers.d2,
+		renderers.gnuplot,
+	},
 }
 
 M.query_buffer_diagrams = function(bufnr)
-  if not query then
-    query = ts_query.parse(
-      "norg",
-      [[
+	if not query then
+		query = vim.treesitter.query.parse(
+			"norg",
+			[[
       (ranged_verbatim_tag
         name: (tag_name) @tag_name
         (tag_parameters)? @tag_params
         content: (ranged_verbatim_tag_content) @content
       )
       ]]
-    )
-  end
+		)
+	end
 
-  local buf = bufnr or vim.api.nvim_get_current_buf()
-  local parser = vim.treesitter.get_parser(buf, "norg")
-  parser:parse(true)
+	local buf = bufnr or vim.api.nvim_get_current_buf()
+	local parser = vim.treesitter.get_parser(buf, "norg")
+	parser:parse(true)
 
-  local root = parser:parse()[1]:root()
-  local matches = query:iter_captures(root, buf)
+	local root = parser:parse()[1]:root()
+	local matches = query:iter_captures(root, buf)
 
-  ---@type Diagram[]
-  local diagrams = {}
-  local current_language = nil
-  ---@type { start_row: number, start_col: number, end_row: number, end_col: number }
-  local current_range = nil
+	---@type Diagram[]
+	local diagrams = {}
+	local current_language = nil
+	---@type { start_row: number, start_col: number, end_row: number, end_col: number }
+	local current_range = nil
 
-  for id, node in matches do
-    local key = query.captures[id]
-    local value = vim.treesitter.get_node_text(node, buf)
+	for id, node in matches do
+		local key = query.captures[id]
+		local value = vim.treesitter.get_node_text(node, buf)
 
-    if key == "tag_name" then
-      local start_row, start_col, _, _ = node:range()
-      current_range = {
-        start_row = start_row,
-        start_col = start_col,
-        end_row = 0,
-        end_col = 0,
-      }
-    elseif key == "tag_params" then
-      current_language = value
-    elseif key == "content" then
-      if
-        current_language == "mermaid"
-        or current_language == "plantuml"
-        or current_language == "d2"
-        or current_language == "gnuplot"
-      then
-        local _, _, end_row, end_col = node:range()
-        current_range.end_row = end_row
-        current_range.end_col = end_col
-        table.insert(diagrams, {
-          bufnr = buf,
-          renderer_id = current_language,
-          source = value,
-          range = current_range,
-        })
-      end
-    end
-  end
+		if key == "tag_name" then
+			current_language = nil
+			local start_row, start_col, _, _ = node:range()
+			current_range = {
+				start_row = start_row,
+				start_col = start_col,
+				end_row = 0,
+				end_col = 0,
+			}
+		elseif key == "tag_params" then
+			current_language = value
+		elseif key == "content" then
+			if
+				current_language == "mermaid"
+				or current_language == "plantuml"
+				or current_language == "d2"
+				or current_language == "gnuplot"
+			then
+				local _, _, end_row, end_col = node:range()
+				current_range.end_row = end_row
+				current_range.end_col = end_col
+				table.insert(diagrams, {
+					bufnr = buf,
+					renderer_id = current_language,
+					source = value,
+					range = current_range,
+				})
+			end
+		end
+	end
 
-  return diagrams
+	return diagrams
 end
 
 return M

--- a/lua/diagram/renderers/d2.lua
+++ b/lua/diagram/renderers/d2.lua
@@ -11,7 +11,7 @@
 
 ---@class Renderer<D2Options>
 local M = {
-  id = "d2",
+	id = "d2",
 }
 
 -- fs cache
@@ -20,74 +20,91 @@ vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options D2Options
+---@param on_finish? function
 ---@return table|nil
-M.render = function(source, options)
-  local hash = vim.fn.sha256(M.id .. ":" .. source)
+M.render = function(source, options, on_finish)
+	local hash = vim.fn.sha256(M.id .. ":" .. source .. ":" .. vim.inspect(options))
 
-  if options.format == nil then
-      options.format = "png"
-  end
-  local path = vim.fn.resolve(cache_dir .. "/" .. hash .. options.format)
-  if vim.fn.filereadable(path) == 1 then return { file_path = path } end
+	if options.format == nil then
+		options.format = "png"
+	end
+	local path = vim.fn.resolve(cache_dir .. "/" .. hash .. options.format)
+	if vim.fn.filereadable(path) == 1 then
+		return { file_path = path }
+	end
 
-  if not vim.fn.executable("d2") then
-    vim.notify("d2 not found in PATH. Please install D2 to use D2 diagrams.", vim.log.levels.ERROR, { title = "Diagram.nvim" })
-    return nil
-  end
+	if not vim.fn.executable("d2") then
+		vim.notify(
+			"d2 not found in PATH. Please install D2 to use D2 diagrams.",
+			vim.log.levels.ERROR,
+			{ title = "Diagram.nvim" }
+		)
+		return nil
+	end
 
-  local tmpsource = vim.fn.tempname()
-  vim.fn.writefile(vim.split(source, "\n"), tmpsource)
+	local tmpsource = vim.fn.tempname()
+	vim.fn.writefile(vim.split(source, "\n"), tmpsource)
 
-  local command_parts = {
-    "d2",
-  }
+	local command_parts = {
+		"d2",
+	}
 
-  -- Add custom CLI arguments if provided
-  if options.cli_args and #options.cli_args > 0 then vim.list_extend(command_parts, options.cli_args) end
+	-- Add custom CLI arguments if provided
+	if options.cli_args and #options.cli_args > 0 then
+		vim.list_extend(command_parts, options.cli_args)
+	end
 
-  -- Add input and output files
-  table.insert(command_parts, tmpsource)
-  table.insert(command_parts, path)
+	-- Add input and output files
+	table.insert(command_parts, tmpsource)
+	table.insert(command_parts, path)
 
-  -- Add standard options
-  if options.theme_id then
-    table.insert(command_parts, "-t")
-    table.insert(command_parts, options.theme_id)
-  end
-  if options.dark_theme_id then
-    table.insert(command_parts, "--dark-theme")
-    table.insert(command_parts, options.dark_theme_id)
-  end
-  if options.scale then
-    table.insert(command_parts, "--scale")
-    table.insert(command_parts, options.scale)
-  end
-  if options.layout then
-    table.insert(command_parts, "--layout")
-    table.insert(command_parts, options.layout)
-  end
-  if options.sketch then table.insert(command_parts, "-s") end
+	-- Add standard options
+	if options.theme_id then
+		table.insert(command_parts, "-t")
+		table.insert(command_parts, options.theme_id)
+	end
+	if options.dark_theme_id then
+		table.insert(command_parts, "--dark-theme")
+		table.insert(command_parts, options.dark_theme_id)
+	end
+	if options.scale then
+		table.insert(command_parts, "--scale")
+		table.insert(command_parts, options.scale)
+	end
+	if options.layout then
+		table.insert(command_parts, "--layout")
+		table.insert(command_parts, options.layout)
+	end
+	if options.sketch then
+		table.insert(command_parts, "-s")
+	end
 
-  local command = table.concat(command_parts, " ")
+	local command = command_parts
 
-  local job_id = vim.fn.jobstart(command, {
-    on_stdout = function(job_id, data, event) end,
-    on_stderr = function(job_id, data, event)
-      local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
-      if vim.startswith(error_msg, "success: successfully compiled") then
-          return
-      end
-      if error_msg ~= "" then
-        vim.notify("Failed to render D2 diagram:\n" .. error_msg, vim.log.levels.ERROR, { title = "Diagram.nvim" })
-      end
-    end,
-    on_exit = function(job_id, exit_code, event)
-      -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
-      -- vim.api.nvim_out_write(msg .. "\n")
-    end,
-  })
+	local job_id = vim.fn.jobstart(command, {
+		on_stdout = function(job_id, data, event) end,
+		on_stderr = function(job_id, data, event)
+			local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
+			if vim.startswith(error_msg, "success: successfully compiled") then
+				return
+			end
+			if error_msg ~= "" then
+				vim.notify(
+					"Failed to render D2 diagram:\n" .. error_msg,
+					vim.log.levels.ERROR,
+					{ title = "Diagram.nvim" }
+				)
+			end
+		end,
+		on_exit = function(job_id, exit_code, event)
+			vim.fn.delete(tmpsource)
+			if on_finish then
+				on_finish()
+			end
+		end,
+	})
 
-  return { file_path = path, job_id = job_id }
+	return { file_path = path, job_id = job_id }
 end
 
 return M

--- a/lua/diagram/renderers/gnuplot.lua
+++ b/lua/diagram/renderers/gnuplot.lua
@@ -9,7 +9,7 @@ local cache = {} -- session cache
 
 ---@class Renderer<GnuplotOptions>
 local M = {
-  id = "gnuplot",
+	id = "gnuplot",
 }
 
 -- fs cache
@@ -18,35 +18,48 @@ vim.fn.mkdir(tmpdir, "p")
 
 ---@param source string
 ---@param options GnuplotOptions
+---@param on_finish? function
 ---@return table|nil
-M.render = function(source, options)
-  local hash = vim.fn.sha256(M.id .. ":" .. source)
-  if cache[hash] then return cache[hash] end
+M.render = function(source, options, on_finish)
+	local hash = vim.fn.sha256(M.id .. ":" .. source .. ":" .. vim.inspect(options))
+	if cache[hash] then
+		return { file_path = cache[hash] }
+	end
 
-  local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
-  if vim.fn.filereadable(path) == 1 then return { file_path = path } end
+	local path = vim.fn.resolve(tmpdir .. "/" .. hash .. ".png")
+	if vim.fn.filereadable(path) == 1 then
+		return { file_path = path }
+	end
 
-  if not vim.fn.executable("gnuplot") then
-    vim.notify("gnuplot not found in PATH. Please install gnuplot to use gnuplot diagrams.", vim.log.levels.ERROR, { title = "Diagram.nvim" })
-    return nil
-  end
+	if not vim.fn.executable("gnuplot") then
+		vim.notify(
+			"gnuplot not found in PATH. Please install gnuplot to use gnuplot diagrams.",
+			vim.log.levels.ERROR,
+			{ title = "Diagram.nvim" }
+		)
+		return nil
+	end
 
-  local tmpsource = vim.fn.tempname()
+	local tmpsource = vim.fn.tempname()
 
-  -- Prepare gnuplot script with output settings
-  local script = {}
-  table.insert(script, "set terminal pngcairo")
-  table.insert(script, string.format("set output '%s'", path))
+	-- Prepare gnuplot script with output settings
+	local script = {}
+	table.insert(script, "set terminal pngcairo")
+	table.insert(script, string.format("set output '%s'", path))
 
-  if options.size then table.insert(script, string.format("set size %s", options.size)) end
+	if options.size then
+		table.insert(script, string.format("set size %s", options.size))
+	end
 
-  if options.font then table.insert(script, string.format("set terminal pngcairo font '%s'", options.font)) end
+	if options.font then
+		table.insert(script, string.format("set terminal pngcairo font '%s'", options.font))
+	end
 
-  -- Add theme settings
-  if options.theme == "dark" then
-    table.insert(
-      script,
-      [[
+	-- Add theme settings
+	if options.theme == "dark" then
+		table.insert(
+			script,
+			[[
         set linetype 1 lc rgb "#377EB8"
         set linetype 2 lc rgb "#4DAF4A"
         set linetype 3 lc rgb "#E41A1C"
@@ -56,11 +69,11 @@ M.render = function(source, options)
         set tics tc rgb "#FFFFFF"
         set object 1 rectangle from screen 0,0 to screen 1,1 behind fillcolor rgb "#000000" fillstyle solid 1.0
         ]]
-    )
-  elseif options.theme == "light" or options.theme == nil then
-    table.insert(
-      script,
-      [[
+		)
+	elseif options.theme == "light" or options.theme == nil then
+		table.insert(
+			script,
+			[[
         set linetype 1 lc rgb "#377EB8"
         set linetype 2 lc rgb "#4DAF4A"
         set linetype 3 lc rgb "#E41A1C"
@@ -70,49 +83,62 @@ M.render = function(source, options)
         set tics tc rgb "#000000"
         set object 1 rectangle from screen 0,0 to screen 1,1 behind fillcolor rgb "#FFFFFF" fillstyle solid 1.0
         ]]
-    )
-  elseif type(options.theme) == "string" then
-    -- treat as a custom theme
-    table.insert(script, options.theme)
-  elseif options.theme ~= nil then
-    vim.notify("Invalid gnuplot theme option. Must be 'light', 'dark', or a custom theme string.", vim.log.levels.ERROR, { title = "Diagram.nvim" })
-    return nil
-  end
+		)
+	elseif type(options.theme) == "string" then
+		-- treat as a custom theme
+		table.insert(script, options.theme)
+	elseif options.theme ~= nil then
+		vim.notify(
+			"Invalid gnuplot theme option. Must be 'light', 'dark', or a custom theme string.",
+			vim.log.levels.ERROR,
+			{ title = "Diagram.nvim" }
+		)
+		return nil
+	end
 
-  -- Add the user's source plot commands
-  table.insert(script, source)
+	-- Add the user's source plot commands
+	table.insert(script, source)
 
-  -- Write the complete script to temporary file
-  vim.fn.writefile(vim.split(table.concat(script, "\n"), "\n"), tmpsource)
+	-- Write the complete script to temporary file
+	vim.fn.writefile(vim.split(table.concat(script, "\n"), "\n"), tmpsource)
 
-  -- Build command with optional cli_args
-  local command_parts = { "gnuplot" }
+	-- Build command with optional cli_args
+	local command_parts = { "gnuplot" }
 
-  -- Add custom CLI arguments if provided
-  if options.cli_args and #options.cli_args > 0 then vim.list_extend(command_parts, options.cli_args) end
+	-- Add custom CLI arguments if provided
+	if options.cli_args and #options.cli_args > 0 then
+		vim.list_extend(command_parts, options.cli_args)
+	end
 
-  -- Add the script file
-  table.insert(command_parts, tmpsource)
+	-- Add the script file
+	table.insert(command_parts, tmpsource)
 
-  local command = table.concat(command_parts, " ")
-  local job_id = vim.fn.jobstart(command, {
-    on_stdout = function(job_id, data, event) end,
-    on_stderr = function(job_id, data, event)
-      local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
-      if error_msg ~= "" then
-        vim.notify("Failed to render gnuplot diagram:\n" .. error_msg, vim.log.levels.ERROR, { title = "Diagram.nvim" })
-      end
-    end,
-    on_exit = function(job_id, exit_code, event)
-      -- Clean up temporary script file
-      vim.fn.delete(tmpsource)
-      cache[hash] = path
-      -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
-      -- vim.api.nvim_out_write(msg .. "\n")
-    end,
-  })
+	local command = command_parts
+	local job_id = vim.fn.jobstart(command, {
+		on_stdout = function(job_id, data, event) end,
+		on_stderr = function(job_id, data, event)
+			local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
+			if error_msg ~= "" then
+				vim.notify(
+					"Failed to render gnuplot diagram:\n" .. error_msg,
+					vim.log.levels.ERROR,
+					{ title = "Diagram.nvim" }
+				)
+			end
+		end,
+		on_exit = function(job_id, exit_code, event)
+			-- Clean up temporary script file
+			vim.fn.delete(tmpsource)
+			cache[hash] = path
+			if on_finish then
+				on_finish()
+			end
+			-- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
+			-- vim.api.nvim_out_write(msg .. "\n")
+		end,
+	})
 
-  return { file_path = path, job_id = job_id }
+	return { file_path = path, job_id = job_id }
 end
 
 return M

--- a/lua/diagram/renderers/init.lua
+++ b/lua/diagram/renderers/init.lua
@@ -4,8 +4,8 @@ local mermaid = require("diagram/renderers/mermaid")
 local plantuml = require("diagram/renderers/plantuml")
 
 return {
-  mermaid = mermaid,
-  plantuml = plantuml,
-  d2 = d2,
-  gnuplot = gnuplot,
+	mermaid = mermaid,
+	plantuml = plantuml,
+	d2 = d2,
+	gnuplot = gnuplot,
 }

--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -10,7 +10,7 @@
 
 ---@class Renderer<MermaidOptions>
 local M = {
-  id = "mermaid",
+	id = "mermaid",
 }
 
 -- fs cache
@@ -19,71 +19,86 @@ vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options MermaidOptions
+---@param on_finish? function
 ---@return table|nil
-M.render = function(source, options)
-  local hash = vim.fn.sha256(M.id .. ":" .. source)
-  local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
-  if vim.fn.filereadable(path) == 1 then return { file_path = path } end
+M.render = function(source, options, on_finish)
+	local hash = vim.fn.sha256(M.id .. ":" .. source .. ":" .. vim.inspect(options))
+	local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
+	if vim.fn.filereadable(path) == 1 then
+		return { file_path = path }
+	end
 
-  if not vim.fn.executable("mmdc") then 
-    vim.notify("mmdc not found in PATH. Please install mermaid-cli to use mermaid diagrams.", vim.log.levels.ERROR, { title = "Diagram.nvim" })
-    return nil
-  end
+	if not vim.fn.executable("mmdc") then
+		vim.notify(
+			"mmdc not found in PATH. Please install mermaid-cli to use mermaid diagrams.",
+			vim.log.levels.ERROR,
+			{ title = "Diagram.nvim" }
+		)
+		return nil
+	end
 
-  local tmpsource = vim.fn.tempname()
-  vim.fn.writefile(vim.split(source, "\n"), tmpsource)
+	local tmpsource = vim.fn.tempname()
+	vim.fn.writefile(vim.split(source, "\n"), tmpsource)
 
-  local command_parts = {
-    "mmdc",
-  }
+	local command_parts = {
+		"mmdc",
+	}
 
-  -- Add custom CLI arguments if provided
-  if options.cli_args and #options.cli_args > 0 then vim.list_extend(command_parts, options.cli_args) end
+	-- Add custom CLI arguments if provided
+	if options.cli_args and #options.cli_args > 0 then
+		vim.list_extend(command_parts, options.cli_args)
+	end
 
-  -- Add standard arguments
-  vim.list_extend(command_parts, {
-    "-i",
-    tmpsource,
-    "-o",
-    path,
-  })
-  if options.background then
-    table.insert(command_parts, "-b")
-    table.insert(command_parts, options.background)
-  end
-  if options.theme then
-    table.insert(command_parts, "-t")
-    table.insert(command_parts, options.theme)
-  end
-  if options.scale then
-    table.insert(command_parts, "-s")
-    table.insert(command_parts, options.scale)
-  end
-  if options.width then
-    table.insert(command_parts, "--width")
-    table.insert(command_parts, options.width)
-  end
-  if options.height then
-    table.insert(command_parts, "--height")
-    table.insert(command_parts, options.height)
-  end
+	-- Add standard arguments
+	vim.list_extend(command_parts, {
+		"-i",
+		tmpsource,
+		"-o",
+		path,
+	})
+	if options.background then
+		table.insert(command_parts, "-b")
+		table.insert(command_parts, options.background)
+	end
+	if options.theme then
+		table.insert(command_parts, "-t")
+		table.insert(command_parts, options.theme)
+	end
+	if options.scale then
+		table.insert(command_parts, "-s")
+		table.insert(command_parts, options.scale)
+	end
+	if options.width then
+		table.insert(command_parts, "--width")
+		table.insert(command_parts, options.width)
+	end
+	if options.height then
+		table.insert(command_parts, "--height")
+		table.insert(command_parts, options.height)
+	end
 
-  local command = table.concat(command_parts, " ")
+	local command = command_parts
 
-  local job_id = vim.fn.jobstart(command, {
-    on_stdout = function(job_id, data, event) end,
-    on_stderr = function(job_id, data, event)
-      local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
-      if error_msg ~= "" then
-        vim.notify("Failed to render mermaid diagram:\n" .. error_msg, vim.log.levels.ERROR, { title = "Diagram.nvim" })
-      end
-    end,
-    on_exit = function(job_id, exit_code, event)
-      -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
-      -- vim.api.nvim_out_write(msg .. "\n")
-    end,
-  })
-  return { file_path = path, job_id = job_id }
+	local job_id = vim.fn.jobstart(command, {
+		on_stdout = function(job_id, data, event) end,
+		on_stderr = function(job_id, data, event)
+			local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
+			if error_msg ~= "" then
+				vim.notify(
+					"Failed to render mermaid diagram:\n" .. error_msg,
+					vim.log.levels.ERROR,
+					{ title = "Diagram.nvim" }
+				)
+			end
+		end,
+		on_exit = function(job_id, exit_code, event)
+			vim.fn.delete(tmpsource)
+			if on_finish then
+				on_finish()
+			end
+		end,
+	})
+	return { file_path = path, job_id = job_id }
 end
 
 return M

--- a/lua/diagram/renderers/plantuml.lua
+++ b/lua/diagram/renderers/plantuml.lua
@@ -6,7 +6,7 @@
 
 ---@class Renderer<PlantUMLOptions>
 local M = {
-  id = "plantuml",
+	id = "plantuml",
 }
 
 -- fs cache
@@ -15,62 +15,73 @@ vim.fn.mkdir(cache_dir, "p")
 
 ---@param source string
 ---@param options PlantUMLOptions
+---@param on_finish? function
 ---@return table|nil
-M.render = function(source, options)
-  local hash = vim.fn.sha256(M.id .. ":" .. source)
+M.render = function(source, options, on_finish)
+	local hash = vim.fn.sha256(M.id .. ":" .. source .. ":" .. vim.inspect(options))
 
-  local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
-  if vim.fn.filereadable(path) == 1 then return { file_path = path } end
+	local path = vim.fn.resolve(cache_dir .. "/" .. hash .. ".png")
+	if vim.fn.filereadable(path) == 1 then
+		return { file_path = path }
+	end
 
-  if not vim.fn.executable("plantuml") then
-    vim.notify("plantuml not found in PATH. Please install PlantUML to use PlantUML diagrams.", vim.log.levels.ERROR, { title = "Diagram.nvim" })
-    return nil
-  end
+	if not vim.fn.executable("plantuml") then
+		vim.notify(
+			"plantuml not found in PATH. Please install PlantUML to use PlantUML diagrams.",
+			vim.log.levels.ERROR,
+			{ title = "Diagram.nvim" }
+		)
+		return nil
+	end
 
-  local tmpsource = vim.fn.tempname()
-  vim.fn.writefile(vim.split(source, "\n"), tmpsource)
+	local tmpsource = vim.fn.tempname()
+	vim.fn.writefile(vim.split(source, "\n"), tmpsource)
 
-  local command_parts = {
-    "plantuml",
-  }
+	local command_parts = {
+		"plantuml",
+	}
 
-  -- Add custom CLI arguments if provided
-  if options.cli_args and #options.cli_args > 0 then vim.list_extend(command_parts, options.cli_args) end
+	-- Add custom CLI arguments if provided
+	if options.cli_args and #options.cli_args > 0 then
+		vim.list_extend(command_parts, options.cli_args)
+	end
 
-  -- Add standard arguments
-  vim.list_extend(command_parts, {
-    "-tpng",
-    "-pipe",
-  })
+	-- Add standard arguments
+	vim.list_extend(command_parts, {
+		"-tpng",
+	})
 
-  if options.charset then
-    table.insert(command_parts, "-charset")
-    table.insert(command_parts, options.charset)
-  end
-  table.insert(command_parts, "<")
-  table.insert(command_parts, tmpsource)
+	if options.charset then
+		table.insert(command_parts, "-charset")
+		table.insert(command_parts, options.charset)
+	end
+	table.insert(command_parts, tmpsource)
 
-  local command = table.concat(command_parts, " ")
+	local job_id = vim.fn.jobstart(command_parts, {
+		on_stdout = function(job_id, data, event) end,
+		on_stderr = function(job_id, data, event)
+			local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
+			if error_msg ~= "" then
+				vim.notify(
+					"Failed to render PlantUML diagram:\n" .. error_msg,
+					vim.log.levels.ERROR,
+					{ title = "Diagram.nvim" }
+				)
+			end
+		end,
+		on_exit = function(job_id, exit_code, event)
+			local generated_file = tmpsource .. ".png"
+			if vim.fn.filereadable(generated_file) == 1 then
+				vim.fn.rename(generated_file, path)
+			end
+			vim.fn.delete(tmpsource)
+			if on_finish then
+				on_finish()
+			end
+		end,
+	})
 
-  local job_id = vim.fn.jobstart(
-    command .. " > " .. vim.fn.shellescape(path .. ".new.png"), -- HACK: write to .new.png to prevent rendering a incomplete file
-    {
-      on_stdout = function(job_id, data, event) end,
-      on_stderr = function(job_id, data, event)
-        local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")
-        if error_msg ~= "" then
-          vim.notify("Failed to render PlantUML diagram:\n" .. error_msg, vim.log.levels.ERROR, { title = "Diagram.nvim" })
-        end
-      end,
-      on_exit = function(job_id, exit_code, event)
-        -- local msg = string.format("Job %d exited with code %d.", job_id, exit_code)
-        -- vim.api.nvim_out_write(msg .. "\n")
-        vim.fn.rename(path .. ".new.png", path) -- HACK: rename to remove .new.png
-      end,
-    }
-  )
-
-  return { file_path = path, job_id = job_id }
+	return { file_path = path, job_id = job_id }
 end
 
 return M


### PR DESCRIPTION
### 1. Security Fixes (Critical)
*   **Shell Injection:** Refactored \`mermaid\`, \`d2\`, \`gnuplot\`, and \`plantuml\` renderers to pass command arguments as a **list of strings** to \`vim.fn.jobstart\`. Previously, arguments were concatenated into a single string, making the plugin vulnerable to shell injection if filenames or options contained malicious characters.
*   **PlantUML:** Removed shell redirection (\`>\`) entirely, using \`vim.fn.rename\` for safer file handling.
### 2. Bug Fixes & Correctness
*   **Cache Invalidation:** Fixed a bug where changing renderer options (e.g., \`theme\`, \`scale\`) did not trigger a re-render because the cache hash was based solely on the source code. The hash now includes \`vim.inspect(options)\`.
*   **Gnuplot Cache:** Fixed a type error where the cache returned a \`string\` (path) instead of a \`table\`, causing runtime errors on cache hits.
*   **Neorg Parsing:** Fixed a state leak in \`neorg.lua\` where \`current_language\` wasn't reset, causing code blocks without parameters to inherit the language of the previous block.
*   **Resource Leaks:** Added cleanup logic (\`vim.fn.delete\`) to remove temporary source files after rendering in all renderers.
### 3. Performance & Modernization
*   **Event-Driven Rendering:** Replaced the inefficient polling loop (timer every 100ms) in \`init.lua\` and \`hover.lua\` with a callback-based approach using \`on_exit\`, reducing idle resource usage.
*   **Tree-sitter:** Replaced deprecated \`require(\"vim.treesitter.query\")\` calls with the modern \`vim.treesitter.query.parse\` API."