### PR TITLE
fix(hover): pad buffer to prevent E966 screenpos error

### DIFF
--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -133,14 +133,22 @@ M.show_diagram_hover = function(diagram, integrations, renderer_options)
     vim.bo[buf].bufhidden = "wipe"
     vim.bo[buf].swapfile = false
 
-    -- Add header content
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+    -- Add header content with enough padding lines for image.nvim's
+    -- screenpos() call, which errors with E966 if the buffer has fewer
+    -- lines than the image's y-offset.
+    local header = {
       "# " .. diagram.renderer_id:upper() .. " Diagram",
       "",
       "Press 'q' to close this tab",
       "Press 'o' to open image with system viewer",
       "",
-    })
+    }
+    local win_height = vim.api.nvim_win_get_height(win)
+    local padding = win_height - #header
+    for _ = 1, math.max(0, padding) do
+      table.insert(header, "")
+    end
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, header)
 
     -- Try to render the image
     local image = image_nvim.from_file(renderer_result.file_path, {


### PR DESCRIPTION
## Problem

`show_diagram_hover()` opens a new tab with 5 header lines, then tells image.nvim to render at `y = 5` (line 6). Since the buffer only has 5 lines, image.nvim's call to `screenpos()` throws:

```
E5108: Error executing lua: Vim:E966: Invalid line number: 6
  stack traceback:
    [C]: in function 'screenpos'
    .../image.nvim/lua/image/renderer.lua:227: in function 'render'
    .../diagram.nvim/lua/diagram/hover.lua:156: in function 'show_in_tab'
```

## Fix

Pad the buffer with empty lines up to the window height after the header content, so `screenpos()` always has valid lines to resolve.

## Testing

Tested with WezTerm + image.nvim (kitty backend) on macOS. `<leader>md` on a mermaid block now opens the diagram tab without errors.