### PR TITLE
fix(mermaid): pass command as list to jobstart

### DIFF
--- a/lua/diagram/renderers/mermaid.lua
+++ b/lua/diagram/renderers/mermaid.lua
@@ -68,9 +68,7 @@ M.render = function(source, options)
     table.insert(command_parts, options.height)
   end
 
-  local command = table.concat(command_parts, " ")
-
-  local job_id = vim.fn.jobstart(command, {
+  local job_id = vim.fn.jobstart(command_parts, {
     on_stdout = function(job_id, data, event) end,
     on_stderr = function(job_id, data, event)
       local error_msg = table.concat(data, "\n"):gsub("^%s+", ""):gsub("%s+$", "")


### PR DESCRIPTION
## Summary
- Pass `command_parts` list directly to `vim.fn.jobstart()` instead of concatenating into a string with `table.concat()`
- Avoids shell interpretation that breaks `#` in hex colors (treated as comments) and spaces in file paths
- Follows `:help jobstart()` recommendation: passing a List runs the command directly without shell

Fixes #45
Also fixes #11 — hex background colors no longer need extra quoting