### PR TITLE
fix: fix screenpos

### DIFF
--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -149,7 +149,7 @@ M.show_diagram_hover = function(diagram, integrations, renderer_options)
       with_virtual_padding = true,
       inline = true,
       x = 0,
-      y = 5, -- Start after the header text
+      y = 4, -- Start after the header text
     })
 
     if image then


### PR DESCRIPTION
# Problem 

Buffer header has 5 lines but image.nvim was told `y = 5` (0-indexed),
   which resolves to Neovim line 6 — a line that doesn't exist.
   `screenpos()` then fails with `E966: Invalid line number: 6`.


<img width="1268" height="415" alt="image" src="https://github.com/user-attachments/assets/b2cf8561-3750-4d8d-a8c3-ce4a51be590a" />

# Fix

Changed `y` from `5` to `4` so the image starts on the empty 5th line,
   which exists and sits correctly after all header text.